### PR TITLE
Fix ForEach not adding the element to the stack at the start of each loop

### DIFF
--- a/src/main/java/at/petrak/hexcasting/common/casting/operators/eval/OpForEach.kt
+++ b/src/main/java/at/petrak/hexcasting/common/casting/operators/eval/OpForEach.kt
@@ -22,6 +22,7 @@ object OpForEach : Operator {
             ctx.incDepth()
             val harness = CastingHarness(ctx)
             harness.stack.addAll(stack)
+            harness.stack.add(subdatum)
             for (pat in instrs) {
                 val res = harness.getUpdate(pat.tryGet(), ctx.world)
                 sideEffects.addAll(res.sideEffects)


### PR DESCRIPTION
Thoth's Gambit was broken since the rewrite as it didn't add the elements it iterates over to the stack at the start of each loop. This is a simple fixed since it was just a case of re-adding a line from the previous implementation.