### PR TITLE
Fix error message thrown by OpForEach

### DIFF
--- a/src/main/java/at/petrak/hexcasting/api/Operator.kt
+++ b/src/main/java/at/petrak/hexcasting/api/Operator.kt
@@ -3,6 +3,7 @@ package at.petrak.hexcasting.api
 import at.petrak.hexcasting.common.casting.CastException
 import at.petrak.hexcasting.common.casting.CastingContext
 import net.minecraft.world.phys.Vec3
+import kotlin.math.abs
 
 /**
  * Manipulates the stack in some way, usually by popping some number of values off the stack
@@ -43,7 +44,7 @@ interface Operator {
          */
         @JvmStatic
         inline fun <reified T : Any> List<SpellDatum<*>>.getChecked(idx: Int): T {
-            val x = this.getOrElse(idx) { throw CastException(CastException.Reason.NOT_ENOUGH_ARGS, idx, this.size) }
+            val x = this.getOrElse(idx) { throw CastException(CastException.Reason.NOT_ENOUGH_ARGS, abs(idx), this.size) }
             return x.tryGet()
         }
 

--- a/src/main/java/at/petrak/hexcasting/api/Operator.kt
+++ b/src/main/java/at/petrak/hexcasting/api/Operator.kt
@@ -3,7 +3,6 @@ package at.petrak.hexcasting.api
 import at.petrak.hexcasting.common.casting.CastException
 import at.petrak.hexcasting.common.casting.CastingContext
 import net.minecraft.world.phys.Vec3
-import kotlin.math.abs
 
 /**
  * Manipulates the stack in some way, usually by popping some number of values off the stack
@@ -44,7 +43,7 @@ interface Operator {
          */
         @JvmStatic
         inline fun <reified T : Any> List<SpellDatum<*>>.getChecked(idx: Int): T {
-            val x = this.getOrElse(idx) { throw CastException(CastException.Reason.NOT_ENOUGH_ARGS, abs(idx), this.size) }
+            val x = this.getOrElse(idx) { throw CastException(CastException.Reason.NOT_ENOUGH_ARGS, idx, this.size) }
             return x.tryGet()
         }
 

--- a/src/main/java/at/petrak/hexcasting/common/casting/operators/eval/OpForEach.kt
+++ b/src/main/java/at/petrak/hexcasting/common/casting/operators/eval/OpForEach.kt
@@ -4,12 +4,16 @@ import at.petrak.hexcasting.api.OperationResult
 import at.petrak.hexcasting.api.Operator
 import at.petrak.hexcasting.api.Operator.Companion.getChecked
 import at.petrak.hexcasting.api.SpellDatum
+import at.petrak.hexcasting.common.casting.CastException
 import at.petrak.hexcasting.common.casting.CastingContext
 import at.petrak.hexcasting.common.casting.CastingHarness
 import at.petrak.hexcasting.common.casting.OperatorSideEffect
 
 object OpForEach : Operator {
     override fun operate(stack: MutableList<SpellDatum<*>>, ctx: CastingContext): OperationResult {
+        if (stack.size < 2)
+            throw CastException(CastException.Reason.NOT_ENOUGH_ARGS, 2, stack.size)
+
         val instrs: List<SpellDatum<*>> = stack.getChecked(stack.lastIndex - 1)
         val datums: List<SpellDatum<*>> = stack.getChecked(stack.lastIndex)
         stack.removeLastOrNull()


### PR DESCRIPTION
Added a check for the number of elements on the stack at the start of OpForEach. For now, the number of args is hardcoded, which should probably be changed to a more elegant solution.
Previously the error messages were wrong, as getChecked passes the index that was out of bounds to the NOT_ENOUGH_ARGS CastException, instead of the number of args which are required. It's unclear how to fix it, as getChecked doesn't actually know how many args are required, so this should probably be cleaned up as well.
Therefore, this is more a temporary fix, but it works for now.