### PR TITLE
consolidate cluster_max_harvestables

### DIFF
--- a/Common/src/main/resources/data/minecraft/tags/items/cluster_max_harvestables.json
+++ b/Common/src/main/resources/data/minecraft/tags/items/cluster_max_harvestables.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
+    "hexcasting:jeweler_hammer"
     {
       "id": "#ae2:quartz_pickaxe",
       "required": false

--- a/Fabric/src/generated/resources/data/minecraft/tags/items/cluster_max_harvestables.json
+++ b/Fabric/src/generated/resources/data/minecraft/tags/items/cluster_max_harvestables.json
@@ -1,6 +1,0 @@
-{
-  "replace": false,
-  "values": [
-    "hexcasting:jeweler_hammer"
-  ]
-}

--- a/Forge/src/generated/resources/data/minecraft/tags/items/cluster_max_harvestables.json
+++ b/Forge/src/generated/resources/data/minecraft/tags/items/cluster_max_harvestables.json
@@ -1,6 +1,0 @@
-{
-  "replace": false,
-  "values": [
-    "hexcasting:jeweler_hammer"
-  ]
-}


### PR DESCRIPTION
Moves the jeweler's hammer addition to the Common tag file, and deletes the old duplicated tag files, which eliminates the build issue of the duplicated file.