### PR TITLE
[Fabric] Creates a Variable-Argument Set Gravity, Changes to Support That

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/misc/GravitySetting.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/misc/GravitySetting.java
@@ -1,0 +1,9 @@
+package at.petrak.hexcasting.api.misc;
+
+import net.minecraft.core.Direction;
+
+public record GravitySetting(Direction gravityDirection, boolean permanent, int timeLeft) {
+    public static GravitySetting deny() {
+        return new GravitySetting(Direction.DOWN, true, 0);
+    }
+}

--- a/Common/src/main/java/at/petrak/hexcasting/api/spell/SpellOperator.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/spell/SpellOperator.kt
@@ -17,11 +17,16 @@ interface SpellOperator : Operator {
         ctx: CastingContext
     ): Triple<RenderedSpell, Int, List<ParticleSpray>>?
 
-    override fun operate(continuation: SpellContinuation, stack: MutableList<SpellDatum<*>>, local: SpellDatum<*>, ctx: CastingContext): OperationResult {
+    fun consumeFromStack(stack: MutableList<SpellDatum<*>>, ctx: CastingContext): List<SpellDatum<*>>
+    {
         if (this.argc > stack.size)
             throw MishapNotEnoughArgs(this.argc, stack.size)
         val args = stack.takeLast(this.argc)
         for (_i in 0 until this.argc) stack.removeLast()
+        return args
+    }
+    override fun operate(continuation: SpellContinuation, stack: MutableList<SpellDatum<*>>, local: SpellDatum<*>, ctx: CastingContext): OperationResult {
+        val args = consumeFromStack(stack, ctx)
         val executeResult = this.execute(args, ctx) ?: return OperationResult(continuation, stack, local, listOf())
         val (spell, mana, particles) = executeResult
 

--- a/Common/src/main/java/at/petrak/hexcasting/xplat/IXplatAbstractions.java
+++ b/Common/src/main/java/at/petrak/hexcasting/xplat/IXplatAbstractions.java
@@ -5,6 +5,7 @@ import at.petrak.hexcasting.api.addldata.DataHolder;
 import at.petrak.hexcasting.api.addldata.HexHolder;
 import at.petrak.hexcasting.api.addldata.ManaHolder;
 import at.petrak.hexcasting.api.misc.FrozenColorizer;
+import at.petrak.hexcasting.api.misc.GravitySetting;
 import at.petrak.hexcasting.api.player.FlightAbility;
 import at.petrak.hexcasting.api.player.Sentinel;
 import at.petrak.hexcasting.api.spell.casting.CastingHarness;
@@ -17,6 +18,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.npc.VillagerProfession;
@@ -101,6 +103,11 @@ public interface IXplatAbstractions {
 
     @Nullable
     HexHolder findHexHolder(ItemStack stack);
+
+    GravitySetting getGravitySetting(Entity entity);
+
+    void setGravitySetting(Entity entity, GravitySetting gravity);
+
 
     // coooollooorrrs
 

--- a/Common/src/main/resources/assets/hexcasting/lang/en_us.json
+++ b/Common/src/main/resources/assets/hexcasting/lang/en_us.json
@@ -987,9 +987,10 @@
   "hexcasting.page.interop.3": "Finally, if I find myself interested in the lore and stories of this world, I do not think any notes compiled while examining these interoperations should be considered as anything more than light trifles.",
 
   "hexcasting.entry.interop.gravity": "Gravity Changer",
-  "hexcasting.page.interop.gravity.1": "I have discovered actions to get and set an entity's gravity. I find them interesting, if slightly nauseating.$(br2)Interestingly, although $(l:patterns/great_spells/flight)$(action)Flight/$ is a great spell, and manipulates gravity similarly, these are not. It baffles me why... Perhaps the mod developer wanted players to have fun, for once.",
+  "hexcasting.page.interop.gravity.1": "I have discovered actions to get and set an entity's gravity. I find them interesting, if slightly nauseating.$(br2)Interestingly, although $(l:patterns/great_spells/flight)$(action)Flight/$ is a great spell, and manipulates gravity similarly, these are not. It baffles me why... Perhaps the mod developer wanted players to have fun, for once.  Even stranger, the spell to set gravity accepts different arguments depending on whether I target myself, or others.",
   "hexcasting.page.interop.gravity.get": "Get the main direction gravity pulls the given entity in, as a unit vector. For most entities, this will be down: [0, -1, 0].",
-  "hexcasting.page.interop.gravity.set": "Set the main direction gravity pulls the given entity in. The given vector will be coerced into the nearest axis, as per $(l:patterns/math#hexcasting:coerce_axial)$(action)Axial Purification/$. Costs about 1 $(item)Charged Amethyst Crystal/$.",
+  "hexcasting.page.interop.gravity.set_self": "Set the main direction gravity pulls myself in. The given vector will be coerced into the nearest axis, as per $(l:patterns/math#hexcasting:coerce_axial)$(action)Axial Purification/$. Costs about 1 $(item)Charged Amethyst Crystal/$.",
+  "hexcasting.page.interop.gravity.set_others": "Set the main direction gravity pulls another entity in. The given vector will be coerced into the nearest axis, while the given number determines duration. Costs about 1 $(item)Amethyst Dust/$ for every five seconds.",
 
   "hexcasting.entry.interop.pehkui": "Pehkui",
   "hexcasting.page.interop.pehkui.1": "I have discovered methods of changing the size of entities, and querying how much larger or smaller they are than normal.",

--- a/Common/src/main/resources/data/hexcasting/patchouli_books/thehexbook/en_us/entries/interop/gravity.json
+++ b/Common/src/main/resources/data/hexcasting/patchouli_books/thehexbook/en_us/entries/interop/gravity.json
@@ -18,9 +18,17 @@
       "type": "hexcasting:pattern",
       "op_id": "hexcasting:interop/gravity/set",
       "anchor": "hexcasting:interop/gravity/set",
-      "input": "entity, vector",
+      "input": "entity (caster), vector",
       "output": "",
-      "text": "hexcasting.page.interop.gravity.set"
+      "text": "hexcasting.page.interop.gravity.set_self"
+    },
+    {
+      "type": "hexcasting:pattern",
+      "op_id": "hexcasting:interop/gravity/set",
+      "anchor": "hexcasting:interop/gravity/set",
+      "input": "entity (other), vector, number",
+      "output": "",
+      "text": "hexcasting.page.interop.gravity.set_others"
     }
   ]
 }

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexInitializer.kt
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexInitializer.kt
@@ -15,12 +15,15 @@ import at.petrak.hexcasting.common.misc.Brainsweeping
 import at.petrak.hexcasting.common.misc.PlayerPositionRecorder
 import at.petrak.hexcasting.common.recipe.HexRecipeSerializers
 import at.petrak.hexcasting.fabric.event.VillagerConversionCallback
+import at.petrak.hexcasting.fabric.interop.gravity.OpChangeGravity
 import at.petrak.hexcasting.fabric.network.FabricPacketHandler
 import at.petrak.hexcasting.fabric.recipe.FabricUnsealedIngredient
 import at.petrak.hexcasting.fabric.storage.FabricImpetusStorage
 import at.petrak.hexcasting.interop.HexInterop
+import at.petrak.hexcasting.xplat.IXplatAbstractions
 import io.github.tropheusj.serialization_hooks.ingredient.IngredientDeserializer
 import net.fabricmc.api.ModInitializer
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents
 import net.fabricmc.fabric.api.event.player.AttackBlockCallback
@@ -72,6 +75,11 @@ object FabricHexInitializer : ModInitializer {
         }
 
         ServerTickEvents.END_WORLD_TICK.register(PlayerPositionRecorder::updateAllPlayers)
+        ServerTickEvents.END_WORLD_TICK.register(OpChangeGravity::fabricTickDownAllGravityChanges)
+        // Can register server ticks on a (dedicated) client, but not client ticks on a (dedicated) server.
+        if (IXplatAbstractions.INSTANCE.isPhysicalClient) {
+            ClientTickEvents.END_WORLD_TICK.register(OpChangeGravity::fabricRespawnNormalGrav)
+        }
 
         CommandRegistrationCallback.EVENT.register { dp, _ -> HexCommands.register(dp) }
 

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/cc/CCGravity.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/cc/CCGravity.java
@@ -1,0 +1,65 @@
+package at.petrak.hexcasting.fabric.cc;
+
+import at.petrak.hexcasting.api.misc.GravitySetting;
+import at.petrak.hexcasting.fabric.interop.gravity.OpChangeGravity;
+import dev.onyxstudios.cca.api.v3.component.Component;
+import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.entity.Entity;
+
+public class CCGravity implements Component
+{
+    public static final String
+            TAG_DIRECTION   = "direction",
+            TAG_TIME_LEFT = "time_left",
+            TAG_PERMANENT = "permanent";
+
+    final Entity owner;
+    private       GravitySetting gravitySetting = GravitySetting.deny();
+
+    public CCGravity(Entity owner)
+    {
+        this.owner = owner;
+    }
+
+    public GravitySetting getGravitySetting()
+    {
+        return gravitySetting;
+    }
+
+    public void setGravitySetting(GravitySetting gravity)
+    {
+        this.gravitySetting = gravity;
+    }
+
+    @Override
+    public void readFromNbt(CompoundTag tag)
+    {
+        var dirNum = tag.getInt(TAG_DIRECTION);
+        if (dirNum == Direction.DOWN.get2DDataValue())
+        {
+            this.gravitySetting = GravitySetting.deny();
+        }
+        else
+        {
+            var permanent = tag.getBoolean(TAG_PERMANENT);
+            var timeLeft = tag.getInt(TAG_TIME_LEFT);
+            this.gravitySetting = new GravitySetting(Direction.from2DDataValue(dirNum), permanent, timeLeft);
+            if(!permanent)
+            {
+                OpChangeGravity.EntitiesWithGravitas.Companion.getActiveGravityTimers().add(owner);
+            }
+        }
+    }
+
+    @Override
+    public void writeToNbt(CompoundTag tag)
+    {
+        tag.putInt(TAG_DIRECTION, this.gravitySetting.gravityDirection().get2DDataValue());
+        if (this.gravitySetting.gravityDirection() != Direction.DOWN)
+        {
+            tag.putBoolean(TAG_PERMANENT, this.gravitySetting.permanent());
+            tag.putInt(TAG_TIME_LEFT, this.gravitySetting.timeLeft());
+        }
+    }
+}

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/cc/HexCardinalComponents.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/cc/HexCardinalComponents.java
@@ -15,6 +15,7 @@ import dev.onyxstudios.cca.api.v3.entity.RespawnCopyStrategy;
 import dev.onyxstudios.cca.api.v3.item.ItemComponentFactoryRegistry;
 import dev.onyxstudios.cca.api.v3.item.ItemComponentInitializer;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.item.Items;
 
@@ -30,6 +31,8 @@ public class HexCardinalComponents implements EntityComponentInitializer, ItemCo
         CCSentinel.class);
     public static final ComponentKey<CCFlight> FLIGHT = ComponentRegistry.getOrCreate(modLoc("flight"),
         CCFlight.class);
+    public static final ComponentKey<CCGravity> GRAVITY = ComponentRegistry.getOrCreate(modLoc("gravity"),
+            CCGravity.class);
     public static final ComponentKey<CCHarness> HARNESS = ComponentRegistry.getOrCreate(modLoc("harness"),
         CCHarness.class);
     public static final ComponentKey<CCPatterns> PATTERNS = ComponentRegistry.getOrCreate(modLoc("patterns"),
@@ -53,6 +56,7 @@ public class HexCardinalComponents implements EntityComponentInitializer, ItemCo
         registry.registerFor(ServerPlayer.class, FLIGHT, CCFlight::new);
         registry.registerFor(ServerPlayer.class, HARNESS, CCHarness::new);
         registry.registerFor(ServerPlayer.class, PATTERNS, CCPatterns::new);
+        registry.registerFor(Entity.class, GRAVITY, CCGravity::new);
     }
 
     @Override

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/interop/gravity/OpChangeGravity.kt
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/interop/gravity/OpChangeGravity.kt
@@ -1,31 +1,166 @@
 package at.petrak.hexcasting.fabric.interop.gravity
 
+import at.petrak.hexcasting.api.misc.GravitySetting
+import at.petrak.hexcasting.api.misc.ManaConstants
 import at.petrak.hexcasting.api.spell.*
 import at.petrak.hexcasting.api.spell.casting.CastingContext
+import at.petrak.hexcasting.api.spell.mishaps.MishapNotEnoughArgs
+import at.petrak.hexcasting.xplat.IXplatAbstractions
 import me.andrew.gravitychanger.api.GravityChangerAPI
+import net.minecraft.client.multiplayer.ClientLevel
 import net.minecraft.core.Direction
+import net.minecraft.server.level.ServerLevel
+import net.minecraft.server.level.ServerPlayer
+import net.minecraft.world.damagesource.DamageSource
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.phys.Vec3
+import kotlin.math.roundToInt
 
 object OpChangeGravity : SpellOperator {
     override val argc = 2
+    val maxArgc = 3
+
+    class EntitiesWithGravitas {
+        companion object
+        {
+            val ActiveGravityTimers = mutableListOf<Entity>()
+            val TimersToRemove = mutableListOf<Entity>()
+        }
+    }
+
+    override fun consumeFromStack(stack: MutableList<SpellDatum<*>>, ctx: CastingContext): List<SpellDatum<*>>
+    {
+        if (this.argc > stack.size)
+            throw MishapNotEnoughArgs(this.argc, stack.size)
+        val twoArgs = stack.takeLast(argc)
+        if(twoArgs[0].payload == ctx.caster)
+        {
+            for (_i in 0 until argc) stack.removeLast()
+            return twoArgs
+        }
+        else
+        {
+            val threeArgs = stack.takeLast(maxArgc)
+            for (_i in 0 until maxArgc) stack.removeLast()
+            return threeArgs
+        }
+    }
 
     override fun execute(args: List<SpellDatum<*>>, ctx: CastingContext):
             Triple<RenderedSpell, Int, List<ParticleSpray>> {
         val target = args.getChecked<Entity>(0)
         val vec = args.getChecked<Vec3>(1)
-
         val snapped = Direction.getNearest(vec.x, vec.y, vec.z)
+        val time : Double
+        val infiniteDuration: Boolean
+        val manaCost: Int
+
+        // If casting on self, use the permanent two-arg version
+        // We've already checked once during the arg consume phase, but this is cleaner than trusting counts.
+        if (target == ctx.caster)
+        {
+            infiniteDuration = true
+            time = -1.0
+            manaCost = ManaConstants.CRYSTAL_UNIT * 10
+        }
+        else // if casting on anything else, use the three-arg version.
+        // Shouldn't be possible to get less than two-args here, but I'm paranoid.
+        {
+            val timeRaw = if(args.count() >= 3) {
+                args.getChecked<Double>(2)
+            } else {
+                throw MishapNotEnoughArgs(this.argc + 1, 2)
+            }
+            //We'll 'charge' for duration even if Direction.DOWN, but treat it as an infinite duration anyway; as if it 'finished' to normal gravity.
+            infiniteDuration = snapped == Direction.DOWN
+            manaCost = ManaConstants.DUST_UNIT * (0.20 * (timeRaw + 1.0)).roundToInt()
+            time = timeRaw * 20.0;
+        }
+
         return Triple(
-            Spell(target, snapped),
-            100_000,
+            Spell(target, snapped, infiniteDuration, time.roundToInt()),
+            manaCost,
             listOf(ParticleSpray(target.position(), Vec3.atLowerCornerOf(snapped.normal), 0.1, 0.1))
         )
     }
 
-    private data class Spell(val target: Entity, val dir: Direction) : RenderedSpell {
+    private data class Spell(val target: Entity, val dir: Direction, val permanent: Boolean, val time: Int) : RenderedSpell {
         override fun cast(ctx: CastingContext) {
             GravityChangerAPI.setDefaultGravityDirection(target, dir)
+            IXplatAbstractions.INSTANCE.setGravitySetting(
+                target,
+                GravitySetting(
+                    dir,
+                    permanent,
+                    time
+                ))
+            if(!permanent)
+            {
+                EntitiesWithGravitas.ActiveGravityTimers.add(target)
+            }
+        }
+    }
+
+    private fun tickDownGravity(entity: Entity) {
+        val gravity = IXplatAbstractions.INSTANCE.getGravitySetting(entity);
+        if (gravity != null && gravity.gravityDirection != null) {
+            if (gravity.gravityDirection == Direction.DOWN || !entity.isAlive)
+            {
+                GravityChangerAPI.setDefaultGravityDirection(entity, Direction.DOWN)
+                EntitiesWithGravitas.TimersToRemove.add(entity);
+            }
+            else if (!gravity.permanent) {
+                val gravityTime = gravity.timeLeft - 1
+                if (gravityTime < 0) {
+                    GravityChangerAPI.setDefaultGravityDirection(entity, Direction.DOWN)
+                    IXplatAbstractions.INSTANCE.setGravitySetting(entity, GravitySetting.deny())
+                } else {
+                    IXplatAbstractions.INSTANCE.setGravitySetting(
+                        entity,
+                        GravitySetting(
+                            gravity.gravityDirection,
+                            gravity.permanent,
+                            gravityTime
+                        )
+                    )
+                }
+            }
+            if(entity.y > 5000)
+            {
+                if(entity is ServerPlayer) {
+                    entity.hurt(DamageSource.OUT_OF_WORLD, 1f)
+                }
+                else
+                {
+                    entity.remove(Entity.RemovalReason.DISCARDED);
+                }
+            }
+        }
+    }
+
+    fun fabricTickDownAllGravityChanges(world: ServerLevel)
+    {
+        for (entity in EntitiesWithGravitas.ActiveGravityTimers) {
+            tickDownGravity(entity);
+        }
+        // Have to do this as a separate step, as it's unsafe to modify a list within its iterator.
+        EntitiesWithGravitas.ActiveGravityTimers.removeAll(EntitiesWithGravitas.TimersToRemove)
+    }
+
+    fun fabricRespawnNormalGrav(world: ClientLevel)
+    {
+        // Only player respawn event is in Architect, which we don't (yet) depend on.
+        // Thus, this mess.  Thankfully, cpu impact should be minimal, even running 20hz.
+        for (player in world.players()) {
+            // This method can only ever fire on the client side; the code below would never run but probably wouldn't be optimized out.
+            // Included for clarity.
+            //if (player !is LocalPlayer)
+            //    continue
+            // And, yes, this is the best test available short of adding network communications;
+            // neither GravityAPI nor CardinalComponents syncs their data.
+            if(player.isDeadOrDying){
+                GravityChangerAPI.setDefaultGravityDirection(player, Direction.DOWN)
+            }
         }
     }
 }

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/interop/gravity/OpChangeGravity.kt
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/interop/gravity/OpChangeGravity.kt
@@ -61,15 +61,15 @@ object OpChangeGravity : SpellOperator {
         {
             infiniteDuration = true
             time = -1.0
-            manaCost = ManaConstants.CRYSTAL_UNIT * 10
+            manaCost = ManaConstants.CRYSTAL_UNIT * 1
         }
         else // if casting on anything else, use the three-arg version.
         // Shouldn't be possible to get less than two-args here, but I'm paranoid.
         {
-            val timeRaw = if(args.count() >= 3) {
+            val timeRaw = if(args.count() >= this.maxArgc) {
                 args.getChecked<Double>(2)
             } else {
-                throw MishapNotEnoughArgs(this.argc + 1, 2)
+                throw MishapNotEnoughArgs(this.maxArgc, args.count())
             }
             //We'll 'charge' for duration even if Direction.DOWN, but treat it as an infinite duration anyway; as if it 'finished' to normal gravity.
             infiniteDuration = snapped == Direction.DOWN

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/xplat/FabricXplatImpl.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/xplat/FabricXplatImpl.java
@@ -4,6 +4,7 @@ import at.petrak.hexcasting.api.addldata.DataHolder;
 import at.petrak.hexcasting.api.addldata.HexHolder;
 import at.petrak.hexcasting.api.addldata.ManaHolder;
 import at.petrak.hexcasting.api.misc.FrozenColorizer;
+import at.petrak.hexcasting.api.misc.GravitySetting;
 import at.petrak.hexcasting.api.mod.HexConfig;
 import at.petrak.hexcasting.api.mod.HexItemTags;
 import at.petrak.hexcasting.api.player.FlightAbility;
@@ -150,7 +151,17 @@ public class FabricXplatImpl implements IXplatAbstractions {
         var cc = HexCardinalComponents.FLIGHT.get(target);
         cc.setFlight(flight);
     }
-
+    @Override
+    public GravitySetting getGravitySetting(Entity target)
+    {
+        var cc = HexCardinalComponents.GRAVITY.get(target);
+        return cc.getGravitySetting();
+    }
+    @Override
+    public void setGravitySetting(Entity target, GravitySetting gravity) {
+        var cc = HexCardinalComponents.GRAVITY.get(target);
+        cc.setGravitySetting(gravity);
+    }
     @Override
     public void setHarness(ServerPlayer target, CastingHarness harness) {
         var cc = HexCardinalComponents.HARNESS.get(target);

--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -66,6 +66,7 @@
       "hexcasting:flight",
       "hexcasting:harness",
       "hexcasting:patterns",
+      "hexcasting:gravity",
 
       "hexcasting:colorizer",
       "hexcasting:data_holder",

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/xplat/ForgeXplatImpl.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/xplat/ForgeXplatImpl.java
@@ -6,6 +6,7 @@ import at.petrak.hexcasting.api.addldata.DataHolder;
 import at.petrak.hexcasting.api.addldata.HexHolder;
 import at.petrak.hexcasting.api.addldata.ManaHolder;
 import at.petrak.hexcasting.api.misc.FrozenColorizer;
+import at.petrak.hexcasting.api.misc.GravitySetting;
 import at.petrak.hexcasting.api.mod.HexItemTags;
 import at.petrak.hexcasting.api.player.FlightAbility;
 import at.petrak.hexcasting.api.player.Sentinel;
@@ -139,6 +140,17 @@ public class ForgeXplatImpl implements IXplatAbstractions {
         }
     }
 
+    @Override
+    public void setGravitySetting(Entity target, GravitySetting setting)
+    {
+        // Does not exist in FORGE ecosystem.
+    }
+    @Override
+    public GravitySetting getGravitySetting(Entity target)
+    {
+        // Does not exist in FORGE ecosystem.
+        return GravitySetting.deny();
+    }
     @Override
     public void setColorizer(Player player, FrozenColorizer colorizer) {
         CompoundTag tag = player.getPersistentData();


### PR DESCRIPTION
This one is more aggressive, and I'm not sure how much of it you will want to take.  In order:
- Separates the SpellOrder logic between consuming iotas from the stack, and the actual execution.  This allows individual spells to have more complex stack interactions without having to reimplement too much, or add complexity for normal spell args.
- Makes OpChangeGravity into:
![image](https://user-images.githubusercontent.com/39036909/180658384-24e3f709-9529-4556-bc31-22d5095794ed.png)
- _I don't expect this to be the final implementation you'd want, if you even want these sort of changes at all_: it's intentionally harder than most normal spells to use for things like a Zone-based approaches using Thoth, and the prices are pretty much just made up wholesale.  A variant that allows casters to target themselves for a timed gravity effect, but also has the two-arg permanent version which mishaps if they use it on anyone else, is just as valid if you'd prefer that implementation.
- Adds the documentation shown above.
- Adds the various support structures necessary to allow that timer tickdown functionality.  Because the full set of all entities is much larger than that of all players, rather than the approach used in OpFlight, this has its own companion object with all entities with active timers.  I'm _not sure how good this is at consistency from server-to-client_; there's no obvious drop-outs in our play, but we haven't been hitting it hard yet and I don't really have a good understanding of how Cardinal Components handles a lot of edge cases.
- Kills players and discards entities that have been thrown too far (>5k blocks) into the sky.  This is probably overkill, but even with the timer it's pretty trivial to shoot someone into orbit, and this way there's a fix other than having an op kill you.

Some particular parts that I'm not hugely happy with:
- This adds a Client-side END_WORLD_TICK event that's basically just there to handle a case where a remote client player is gravity-changed, dies, and then the server think there's upside-up while the client doesn't get that update.  This _probably_ needs to be fixed better in GravityChanger/GravityAPI, but this approach is the best I could come up with on short notice without adding a lot of unnecessary network traffic, or adding a dependency on something like Architectury's ClientRespawnEvent.  Does not handle the connect-to-multiple-server or disconnected-when-timer-runs-out cases.
- Not entirely confident that the current Mishaps give enough insight, especially for Trinket use.  Intentional for Kirin's server, but not necessarily ideal for general use.
- The Forge implementation is basically just ??? right now.  GravityChanger doesn't have a Forge version, so I don't think that matters?
- ((GravityChanger itself probably needs some updating; along with the Client-Server confusion for a death while gravity-changed, there's a number of mixins we had to disable to stop it and Carpet from fighting over.  But even if that's updated, are likely to want to keep the fix implemented here til 1.19.))