### PR TITLE
Add missing properties to a few entries in the docs

### DIFF
--- a/Common/src/main/resources/data/hexcasting/patchouli_books/thehexbook/en_us/entries/patterns/great_spells/greater_sentinel.json
+++ b/Common/src/main/resources/data/hexcasting/patchouli_books/thehexbook/en_us/entries/patterns/great_spells/greater_sentinel.json
@@ -9,6 +9,7 @@
     {
       "type": "hexcasting:pattern",
       "op_id": "hexcasting:sentinel/create/great",
+      "anchor": "hexcasting:sentinel/create/great",
       "text": "hexcasting.page.greater_sentinel.1",
       "input": "vector",
       "output": ""

--- a/Common/src/main/resources/data/hexcasting/patchouli_books/thehexbook/en_us/entries/patterns/meta.json
+++ b/Common/src/main/resources/data/hexcasting/patchouli_books/thehexbook/en_us/entries/patterns/meta.json
@@ -34,6 +34,8 @@
       "type": "hexcasting:pattern",
       "op_id": "hexcasting:halt",
       "anchor": "hexcasting:halt",
+      "input": "",
+      "output": "",
       "text": "hexcasting.page.meta.halt.1"
     },
     {

--- a/Common/src/main/resources/data/hexcasting/patchouli_books/thehexbook/en_us/entries/patterns/patterns_as_iotas.json
+++ b/Common/src/main/resources/data/hexcasting/patchouli_books/thehexbook/en_us/entries/patterns/patterns_as_iotas.json
@@ -18,8 +18,6 @@
       "type": "hexcasting:manual_pattern",
       "header": "hexcasting.spell.hexcasting:escape",
       "anchor": "hexcasting:escape",
-      "input": "",
-      "output": "",
       "text": "hexcasting.page.patterns_as_iotas.escape.1",
       "patterns": {
         "startdir": "WEST",
@@ -34,8 +32,6 @@
       "type": "hexcasting:manual_pattern",
       "header": "hexcasting.spell.hexcasting:open_paren",
       "anchor": "hexcasting:open_paren",
-      "input": "",
-      "output": "",
       "text": "hexcasting.page.patterns_as_iotas.parens.1",
       "patterns": {
         "startdir": "WEST",
@@ -46,8 +42,6 @@
       "type": "hexcasting:manual_pattern",
       "header": "hexcasting.spell.hexcasting:close_paren",
       "anchor": "hexcasting:close_paren",
-      "input": "",
-      "output": "",
       "text": "hexcasting.page.patterns_as_iotas.parens.2",
       "patterns": {
         "startdir": "EAST",

--- a/Common/src/main/resources/data/hexcasting/patchouli_books/thehexbook/en_us/entries/patterns/patterns_as_iotas.json
+++ b/Common/src/main/resources/data/hexcasting/patchouli_books/thehexbook/en_us/entries/patterns/patterns_as_iotas.json
@@ -18,6 +18,8 @@
       "type": "hexcasting:manual_pattern",
       "header": "hexcasting.spell.hexcasting:escape",
       "anchor": "hexcasting:escape",
+      "input": "",
+      "output": "",
       "text": "hexcasting.page.patterns_as_iotas.escape.1",
       "patterns": {
         "startdir": "WEST",
@@ -32,6 +34,8 @@
       "type": "hexcasting:manual_pattern",
       "header": "hexcasting.spell.hexcasting:open_paren",
       "anchor": "hexcasting:open_paren",
+      "input": "",
+      "output": "",
       "text": "hexcasting.page.patterns_as_iotas.parens.1",
       "patterns": {
         "startdir": "WEST",
@@ -42,6 +46,8 @@
       "type": "hexcasting:manual_pattern",
       "header": "hexcasting.spell.hexcasting:close_paren",
       "anchor": "hexcasting:close_paren",
+      "input": "",
+      "output": "",
       "text": "hexcasting.page.patterns_as_iotas.parens.2",
       "patterns": {
         "startdir": "EAST",


### PR DESCRIPTION
Adds the following missing properties:

* Greater Sentinel: `anchor`
* Charon: `input`, `output`
* Consideration: `input`, `output`
* Introspection: `input`, `output`
* Retrospection: `input`, `output`

I generated the docs on my machine with these changes and everything seems to be working. I didn't build the mod because I don't have a dev environment set up, but I don't *think* these changes would break anything?

(I found these with [HexBug's type scraper](https://github.com/object-Object/HexBug/blob/main/scrape_book_types.py))