### PR TITLE
[Bandaid for #414] Disabled Phosphorus

### DIFF
--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -110,7 +110,7 @@ dependencies {
     // sodium is causing frustum mixin errors so don't use it
 //    modImplementation "maven.modrinth:sodium:${sodiumVersion}"
     modImplementation "maven.modrinth:lithium:${lithiumVersion}"
-    modImplementation "maven.modrinth:phosphor:${phosphorVersion}"
+    //modImplementation "maven.modrinth:phosphor:${phosphorVersion}"
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
World after a minute or so of joining will crash due to a lighting mishap [note: not a spell mishap just to clarify]

Disabling Phosphorus from the buildscript stopped the issue

See #414 for more information