### PR TITLE
Make interop patchouli flag only set if it's true

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/interop/HexInterop.java
+++ b/Common/src/main/java/at/petrak/hexcasting/interop/HexInterop.java
@@ -67,6 +67,8 @@ public class HexInterop {
             }
         }
 
-        PatchouliAPI.get().setConfigFlag(PATCHOULI_ANY_INTEROP_FLAG, anyInterop);
+        if (anyInterop) {
+            PatchouliAPI.get().setConfigFlag(PATCHOULI_ANY_INTEROP_FLAG, true);
+        }
     }
 }


### PR DESCRIPTION
This change makes hex not set the flag to false if it didn't find any of its own interop options. 

This doesn't change anything within the mod itself, an unset flag is off by default, but it means that if funky load ordering makes this run after an addon has set the flag to true, it won't reset back to false.