### PR TITLE
More blanketcon restrictions

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/CircleCastEnv.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/CircleCastEnv.java
@@ -79,7 +79,7 @@ public class CircleCastEnv extends CastingEnvironment {
         var sound = result.getSound().sound();
         if (sound != null) {
             var soundPos = this.execState.currentPos;
-            this.world.playSound(null, soundPos, sound, SoundSource.PLAYERS, 1f, 1f);
+            this.world.playSound(null, soundPos, sound, SoundSource.PLAYERS, (float) HexConfig.common().castingVolumeMultiplier(), 1f);
         }
 
         // TODO: this is gonna bite us in the bum someday

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/StaffCastEnv.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/StaffCastEnv.java
@@ -7,6 +7,7 @@ import at.petrak.hexcasting.api.casting.eval.ExecutionClientView;
 import at.petrak.hexcasting.api.casting.eval.ResolvedPattern;
 import at.petrak.hexcasting.api.casting.iota.PatternIota;
 import at.petrak.hexcasting.api.casting.math.HexCoord;
+import at.petrak.hexcasting.api.mod.HexConfig;
 import at.petrak.hexcasting.api.mod.HexStatistics;
 import at.petrak.hexcasting.api.pigment.FrozenPigment;
 import at.petrak.hexcasting.common.msgs.*;
@@ -47,7 +48,7 @@ public class StaffCastEnv extends PlayerBasedCastEnv {
         if (sound != null) {
             var soundPos = this.caster.position();
             this.world.playSound(null, soundPos.x, soundPos.y, soundPos.z,
-                sound, SoundSource.PLAYERS, 1f, 1f);
+                sound, SoundSource.PLAYERS, (float) HexConfig.common().castingVolumeMultiplier(), 1f);
         }
     }
 

--- a/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
@@ -27,6 +27,8 @@ public class HexConfig {
 
         int artifactCooldown();
 
+        double castingVolumeMultiplier();
+
         long DEFAULT_DUST_MEDIA_AMOUNT = MediaConstants.DUST_UNIT;
         long DEFAULT_SHARD_MEDIA_AMOUNT = MediaConstants.SHARD_UNIT;
         long DEFAULT_CHARGED_MEDIA_AMOUNT = MediaConstants.CRYSTAL_UNIT;
@@ -36,9 +38,11 @@ public class HexConfig {
         int DEFAULT_TRINKET_COOLDOWN = 5;
         int DEFAULT_ARTIFACT_COOLDOWN = 3;
 
+        double DEFAULT_CASTING_VOLUME_MULTIPLIER = 0.05;
     }
 
     public interface ClientConfigAccess {
+
         boolean ctrlTogglesOffStrokeOrder();
 
         boolean invertSpellbookScrollDirection();
@@ -54,6 +58,7 @@ public class HexConfig {
     }
 
     public interface ServerConfigAccess {
+
         int opBreakHarvestLevelBecauseForgeThoughtItWasAGoodIdeaToImplementHarvestTiersUsingAnHonestToGodTopoSort();
 
         int maxOpCount();

--- a/Common/src/main/java/at/petrak/hexcasting/common/items/magic/ItemPackagedHex.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/items/magic/ItemPackagedHex.java
@@ -7,8 +7,10 @@ import at.petrak.hexcasting.api.casting.iota.Iota;
 import at.petrak.hexcasting.api.casting.iota.IotaType;
 import at.petrak.hexcasting.api.casting.iota.PatternIota;
 import at.petrak.hexcasting.api.item.HexHolderItem;
+import at.petrak.hexcasting.api.mod.HexConfig;
 import at.petrak.hexcasting.api.pigment.FrozenPigment;
 import at.petrak.hexcasting.api.utils.NBTHelper;
+import at.petrak.hexcasting.common.misc.AdventureHelper;
 import at.petrak.hexcasting.common.msgs.MsgNewSpiralPatternsS2C;
 import at.petrak.hexcasting.xplat.IXplatAbstractions;
 import net.minecraft.nbt.CompoundTag;
@@ -122,6 +124,10 @@ public abstract class ItemPackagedHex extends ItemMediaHolder implements HexHold
             return InteractionResultHolder.success(stack);
         }
 
+        if (AdventureHelper.canUseLoose(player, stack, world, player.position())) {
+            return InteractionResultHolder.success(stack);
+        }
+
         List<Iota> instrs = getHex(stack, (ServerLevel) world);
         if (instrs == null) {
             return InteractionResultHolder.fail(stack);
@@ -162,7 +168,7 @@ public abstract class ItemPackagedHex extends ItemMediaHolder implements HexHold
         if (sound != null) {
             var soundPos = sPlayer.position();
             sPlayer.level().playSound(null, soundPos.x, soundPos.y, soundPos.z,
-                    sound, SoundSource.PLAYERS, 1f, 1f);
+                    sound, SoundSource.PLAYERS, (float) HexConfig.common().castingVolumeMultiplier(), 1f);
         }
 
         if (broken) {

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
@@ -77,6 +77,9 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         @ConfigEntry.Gui.Tooltip
         private int artifactCooldown = DEFAULT_ARTIFACT_COOLDOWN;
 
+        @ConfigEntry.Gui.Tooltip
+        private double castingVolumeMultiplier = DEFAULT_CASTING_VOLUME_MULTIPLIER;
+
 
         @Override
         public void validatePostLoad() throws ValidationException {
@@ -119,6 +122,11 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         @Override
         public int artifactCooldown() {
             return artifactCooldown;
+        }
+
+        @Override
+        public double castingVolumeMultiplier() {
+            return castingVolumeMultiplier;
         }
     }
 

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
@@ -20,6 +20,8 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
     private static ForgeConfigSpec.IntValue trinketCooldown;
     private static ForgeConfigSpec.IntValue artifactCooldown;
 
+    private static ForgeConfigSpec.DoubleValue castingVolumeMultiplier;
+
     public ForgeHexConfig(ForgeConfigSpec.Builder builder) {
         builder.push("Media Amounts");
         dustMediaAmount = builder.comment("How much media a single Amethyst Dust item is worth")
@@ -40,6 +42,10 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
         artifactCooldown = builder.comment("Cooldown in ticks of a artifact")
             .defineInRange("artifactCooldown", DEFAULT_ARTIFACT_COOLDOWN, 0, Integer.MAX_VALUE);
         builder.pop();
+
+        castingVolumeMultiplier = builder.comment(
+                        "Multiplier for casting sounds made by circles, staff casting and casting items")
+                .defineInRange("castingVolumeMultiplier", DEFAULT_CASTING_VOLUME_MULTIPLIER, 0.0, 1.0);
     }
 
     @Override
@@ -75,6 +81,11 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
     @Override
     public int artifactCooldown() {
         return artifactCooldown.get();
+    }
+
+    @Override
+    public double castingVolumeMultiplier() {
+        return castingVolumeMultiplier.get();
     }
 
     public static class Client implements HexConfig.ClientConfigAccess {


### PR DESCRIPTION
Volume multiplier (set to 1/20th by default cause LOUD) and disallow casting items with same logic as staves