### PR TITLE
Fix Media Phial consumption priority on Forge

### DIFF
--- a/Forge/src/main/java/at/petrak/hexcasting/forge/cap/adimpl/CapItemMediaHolder.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/cap/adimpl/CapItemMediaHolder.java
@@ -37,7 +37,7 @@ public record CapItemMediaHolder(MediaHolderItem holder,
 
     @Override
     public int getConsumptionPriority() {
-        return 40;
+        return ADMediaHolder.BATTERY_PRIORITY;
     }
 
     @Override


### PR DESCRIPTION
Priority on non-static media holder items was incorrectly hardcoded to 40 instead of the ADMediaHolder constant, 4000, so phials were being targeted last instead of first.