### PR TITLE
fix vectors with even a single 0 component being considered falsy

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/Vec3Iota.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/Vec3Iota.java
@@ -29,7 +29,7 @@ public class Vec3Iota extends Iota {
     @Override
     public boolean isTruthy() {
         var v = this.getVec3();
-        return v.x != 0.0 || v.y != 0.0 || v.z != 0.0;
+        return !(v.x == 0.0 && v.y == 0.0 && v.z == 0.0);
     }
 
     @Override

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/Vec3Iota.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/Vec3Iota.java
@@ -29,7 +29,7 @@ public class Vec3Iota extends Iota {
     @Override
     public boolean isTruthy() {
         var v = this.getVec3();
-        return v.x != 0.0 && v.y != 0.0 && v.z != 0.0;
+        return v.x != 0.0 || v.y != 0.0 || v.z != 0.0;
     }
 
     @Override


### PR DESCRIPTION
Currently, if you use Augur's Purification on a vector which has a single zero in it, it will return false. This fixes that, so it should now only return false for (0,0,0) vectors.