### PR TITLE
Make public some casting environment methods

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
@@ -376,7 +376,7 @@ public abstract class CastingEnvironment {
     /**
      * Get all the item stacks this env can use.
      */
-    protected abstract List<ItemStack> getUsableStacks(StackDiscoveryMode mode);
+    public abstract List<ItemStack> getUsableStacks(StackDiscoveryMode mode);
 
     protected List<ItemStack> getUsableStacksForPlayer(StackDiscoveryMode mode, @Nullable InteractionHand castingHand
         , ServerPlayer caster) {
@@ -444,7 +444,7 @@ public abstract class CastingEnvironment {
     /**
      * Get the primary/secondary item stacks this env can use (i.e. main hand and offhand for the player).
      */
-    protected abstract List<HeldItemInfo> getPrimaryStacks();
+    public abstract List<HeldItemInfo> getPrimaryStacks();
 
     protected List<HeldItemInfo> getPrimaryStacksForPlayer(InteractionHand castingHand, ServerPlayer caster) {
         var primaryItem = caster.getItemInHand(castingHand);
@@ -597,7 +597,7 @@ public abstract class CastingEnvironment {
     /**
      * The order/mode stacks should be discovered in
      */
-    protected enum StackDiscoveryMode {
+    public enum StackDiscoveryMode {
         /**
          * When finding items to pick (hotbar)
          */

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/CircleCastEnv.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/CircleCastEnv.java
@@ -169,7 +169,7 @@ public class CircleCastEnv extends CastingEnvironment {
 
     @Override
     // TODO: Could do something like get items in inventories adjacent to the circle?
-    protected List<ItemStack> getUsableStacks(StackDiscoveryMode mode) {
+    public List<ItemStack> getUsableStacks(StackDiscoveryMode mode) {
         if (this.getCaster() != null)
             return getUsableStacksForPlayer(mode, null, this.getCaster());
         return new ArrayList<>();
@@ -177,7 +177,7 @@ public class CircleCastEnv extends CastingEnvironment {
 
     @Override
     // TODO: Adjacent inv!
-    protected List<HeldItemInfo> getPrimaryStacks() {
+    public List<HeldItemInfo> getPrimaryStacks() {
         if (this.getCaster() != null)
             return getPrimaryStacksForPlayer(InteractionHand.OFF_HAND, this.getCaster());
         return List.of();

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/PlayerBasedCastEnv.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/PlayerBasedCastEnv.java
@@ -84,12 +84,12 @@ public abstract class PlayerBasedCastEnv extends CastingEnvironment {
     }
 
     @Override
-    protected List<ItemStack> getUsableStacks(StackDiscoveryMode mode) {
+    public List<ItemStack> getUsableStacks(StackDiscoveryMode mode) {
         return getUsableStacksForPlayer(mode, castingHand, caster);
     }
 
     @Override
-    protected List<HeldItemInfo> getPrimaryStacks() {
+    public List<HeldItemInfo> getPrimaryStacks() {
         return getPrimaryStacksForPlayer(this.castingHand, this.caster);
     }
 


### PR DESCRIPTION
I can think of at least a few cases in addons where a person would want to perform their own search of what a casting environment has to offer. Features in base generally shouldn't be done just for addons but I don't see why these very useful methods should be protected and it's currently impossible to access them with usual techniques like invokers because one of the parameters is also a protected enum. Access wideners also don't work because those exclusively only work for base Minecraft classes, not other mods.