### PR TITLE
Optimized Spell Circles

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/BlockEntityAbstractImpetus.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/BlockEntityAbstractImpetus.java
@@ -189,6 +189,12 @@ public abstract class BlockEntityAbstractImpetus extends HexBlockEntity implemen
             this.getBlockState().setValue(BlockCircleComponent.ENERGIZED, true));
     }
 
+    /**
+     * Generate the AABB bounds of a spell circle from the list of block positions that make it up.
+     *
+     * @deprecated No longer used, since the AABB is now generated during startup and stored as a pair of corners.
+     */
+    @Deprecated(since = "0.11.4")
     @Contract(pure = true)
     protected static AABB getBounds(List<BlockPos> poses) {
         int minX = Integer.MAX_VALUE;

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/CircleExecutionState.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/CircleExecutionState.java
@@ -102,10 +102,10 @@ public class CircleExecutionState {
         var todo = new Stack<Pair<Direction, BlockPos>>();
         todo.add(Pair.of(impetus.getStartDirection(), impetus.getBlockPos().relative(impetus.getStartDirection())));
         var seenGoodPosSet = new HashSet<BlockPos>();
-        var positiveBlock = new BlockPos.MutableBlockPos();
-        var negativeBlock = new BlockPos.MutableBlockPos();
         var impetusPos = impetus.getBlockPos();
-        var lastBlockPos = new BlockPos.MutableBlockPos(impetusPos.getX(),impetusPos.getY(),impetusPos.getZ());
+        var positiveBlock = impetusPos.mutable();
+        var negativeBlock = impetusPos.mutable();
+        var lastBlockPos = impetusPos.mutable();
 
         while (!todo.isEmpty()) {
             var pair = todo.pop();

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/CircleExecutionState.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/CircleExecutionState.java
@@ -141,13 +141,15 @@ public class CircleExecutionState {
         if (lastBlockPos == impetus.getBlockPos()) {
             return new Result.Err<>(null);
         } else if (!seenGoodPosSet.contains(impetus.getBlockPos())) {
-            // we can't enter from the side the directrix exits from, so this means we couldn't loop back.
+            // we can't enter from the side the impetus exits from, so this means we couldn't loop back.
             // the last item we tried to examine will always be a terminal slate (b/c if it wasn't,
             // then the *next* slate would be last qed)
             return new Result.Err<>(lastBlockPos);
         }
 
-        seenGoodPosSet.add(impetus.getBlockPos());
+        var reachedPositions = new HashSet<BlockPos>();
+        reachedPositions.add(impetus.getBlockPos());
+
         FrozenPigment colorizer = null;
         UUID casterUUID;
         if (caster == null) {
@@ -158,7 +160,7 @@ public class CircleExecutionState {
         }
         return new Result.Ok<>(
             new CircleExecutionState(impetus.getBlockPos(), impetus.getStartDirection(),
-                seenGoodPosSet, impetus.getBlockPos().offset(impetus.getStartDirection().getNormal()),
+                reachedPositions, impetus.getBlockPos().offset(impetus.getStartDirection().getNormal()),
                 impetus.getStartDirection(), new CastingImage(), casterUUID, colorizer, 0L,
                 positiveBlock.move(1,1,1), negativeBlock));
     }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/ICircleComponent.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/ICircleComponent.java
@@ -135,8 +135,8 @@ public interface ICircleComponent {
             var state = impetus.getExecutionState();
 
             // This is a good use of my time
-            var note = state.reachedPositions.size() - 1;
-            var semitone = impetus.semitoneFromScale(note);
+            var note = state.reachedSlate - 1;
+            var semitone = impetus.semitoneFromScale((int) note);
             pitch = (float) Math.pow(2.0, (semitone - 8) / 12d);
         }
         world.playSound(null, vpos.x, vpos.y, vpos.z, sound, SoundSource.BLOCKS, 1f, pitch);

--- a/Common/src/main/java/at/petrak/hexcasting/common/blocks/circles/impetuses/BlockEntityRedstoneImpetus.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/blocks/circles/impetuses/BlockEntityRedstoneImpetus.java
@@ -88,7 +88,6 @@ public class BlockEntityRedstoneImpetus extends BlockEntityAbstractImpetus {
         if (e instanceof ServerPlayer player) {
             return player;
         } else {
-            HexAPI.LOGGER.error("Entity {} stored in a cleric impetus wasn't a player somehow", e);
             return null;
         }
     }

--- a/Common/src/main/java/at/petrak/hexcasting/common/blocks/circles/impetuses/BlockEntityRedstoneImpetus.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/blocks/circles/impetuses/BlockEntityRedstoneImpetus.java
@@ -88,7 +88,7 @@ public class BlockEntityRedstoneImpetus extends BlockEntityAbstractImpetus {
         if (e instanceof ServerPlayer player) {
             return player;
         } else {
-            return null;
+            HexAPI.LOGGER.error("Entity {} stored in a cleric impetus wasn't a player somehow", e);
         }
     }
 

--- a/Common/src/main/java/at/petrak/hexcasting/common/blocks/circles/impetuses/BlockEntityRedstoneImpetus.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/blocks/circles/impetuses/BlockEntityRedstoneImpetus.java
@@ -88,6 +88,7 @@ public class BlockEntityRedstoneImpetus extends BlockEntityAbstractImpetus {
         if (e instanceof ServerPlayer player) {
             return player;
         } else {
+            HexAPI.LOGGER.error("Entity {} stored in a cleric impetus wasn't a player somehow", e);
             return null;
         }
     }


### PR DESCRIPTION
Replaced `knownPositions` with 2 Block Positions, so a AABB list would not need to be saved and loaded.
Made `reachedPositions` into a long; this is to remove a chunk ban and memory leak issue that happen when a Spell Circle loops for too long.