### PR TITLE
Check the center of BlockPos for ambit instead of the corner

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/CastingEnvironment.java
@@ -330,13 +330,15 @@ public abstract class CastingEnvironment {
     }
 
     public final void assertPosInRange(BlockPos vec) throws MishapBadLocation {
-        this.assertVecInRange(new Vec3(vec.getX(), vec.getY(), vec.getZ()));
+        Vec3 centered = Vec3.atCenterOf(vec);
+        this.assertVecInRange(centered);
     }
 
     public final void assertPosInRangeForEditing(BlockPos vec) throws MishapBadLocation {
-        this.assertVecInRange(new Vec3(vec.getX(), vec.getY(), vec.getZ()));
+        Vec3 centered = Vec3.atCenterOf(vec);
+        this.assertVecInRange(centered);
         if (!this.canEditBlockAt(vec))
-            throw new MishapBadLocation(Vec3.atCenterOf(vec), "forbidden");
+            throw new MishapBadLocation(centered, "forbidden");
     }
 
     public final boolean canEditBlockAt(BlockPos vec) {


### PR DESCRIPTION
not sure if the `isVecInRange` inside `canEditBlockAt` could be removed safely `_(:з」∠)_`
Fixes #946. Fixes #958.