### PR TITLE
queueExecuteAndWrapIotas: allow specifying continuation

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
@@ -41,7 +41,8 @@ class CastingVM(var image: CastingImage, val env: CastingEnvironment) {
     @JvmOverloads
     fun queueExecuteAndWrapIotas(iotas: List<Iota>, world: ServerLevel, nextContinuation: SpellContinuation = SpellContinuation.Done): ExecutionClientView {
         // Initialize the continuation stack to a single top-level eval for all iotas.
-        var continuation = nextContinuation.pushFrame(FrameEvaluate(SpellList.LList(0, iotas), false))
+        // HACK: Ideally, we'd have a separate (SpellContinuation, ServerWorld) overload, but then 0.11.3 would cause mixins to break. Look into properly splitting this in 1.21?
+        var continuation = if (iotas.isNotEmpty()) nextContinuation.pushFrame(FrameEvaluate(SpellList.LList(0, iotas), false)) else nextContinuation;
         // Begin aggregating info
         val info = TempControllerInfo(earlyExit = false)
         var lastResolutionType = ResolvedPatternType.UNRESOLVED


### PR DESCRIPTION
Adds a defaulted queueExecuteAndWrapIotas() parameter to allow specifying the continuation (in addition to the generated `FrameEvaluate` frame). This should not change current behavior, and, due to `@JvmOverloads`, does not break compatibility with existing addons.