### PR TITLE
Revert #965

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
@@ -38,11 +38,9 @@ class CastingVM(var image: CastingImage, val env: CastingEnvironment) {
      *
      * Mutates this
      */
-    @JvmOverloads
-    fun queueExecuteAndWrapIotas(iotas: List<Iota>, world: ServerLevel, nextContinuation: SpellContinuation = SpellContinuation.Done): ExecutionClientView {
+    fun queueExecuteAndWrapIotas(iotas: List<Iota>, world: ServerLevel): ExecutionClientView {
         // Initialize the continuation stack to a single top-level eval for all iotas.
-        // HACK: Ideally, we'd have a separate (SpellContinuation, ServerWorld) overload, but then 0.11.3 would cause mixins to break. Look into properly splitting this in 1.21?
-        var continuation = if (iotas.isNotEmpty()) nextContinuation.pushFrame(FrameEvaluate(SpellList.LList(0, iotas), false)) else nextContinuation;
+        var continuation = SpellContinuation.Done.pushFrame(FrameEvaluate(SpellList.LList(0, iotas), false))
         // Begin aggregating info
         val info = TempControllerInfo(earlyExit = false)
         var lastResolutionType = ResolvedPatternType.UNRESOLVED


### PR DESCRIPTION
This reverts commit c64e5d7bc8c9872edd42daa420b29a3649997eda, reversing changes made to 22b7a6f4d00eaafa9b5b83748d5c5b165e80d3a6.

The changes made in #965 were meant to avoid any impact for addons, but we've since realized that adding an optional argument to a method still breaks mixins targeting that method. This caused a crash with HexxyInTheAlps and may also break other addons.

While mixin impacts aren't technically breaking changes, we still don't really want to break an unknown number of addons this close to a release, so we'll resolve this issue by reverting #965 and revisiting this change at a later date.