### PR TITLE
Revert "Revert #965"

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
@@ -38,9 +38,11 @@ class CastingVM(var image: CastingImage, val env: CastingEnvironment) {
      *
      * Mutates this
      */
-    fun queueExecuteAndWrapIotas(iotas: List<Iota>, world: ServerLevel): ExecutionClientView {
+    @JvmOverloads
+    fun queueExecuteAndWrapIotas(iotas: List<Iota>, world: ServerLevel, nextContinuation: SpellContinuation = SpellContinuation.Done): ExecutionClientView {
         // Initialize the continuation stack to a single top-level eval for all iotas.
-        var continuation = SpellContinuation.Done.pushFrame(FrameEvaluate(SpellList.LList(0, iotas), false))
+        // HACK: Ideally, we'd have a separate (SpellContinuation, ServerWorld) overload, but then 0.11.3 would cause mixins to break. Look into properly splitting this in 1.21?
+        var continuation = if (iotas.isNotEmpty()) nextContinuation.pushFrame(FrameEvaluate(SpellList.LList(0, iotas), false)) else nextContinuation;
         // Begin aggregating info
         val info = TempControllerInfo(earlyExit = false)
         var lastResolutionType = ResolvedPatternType.UNRESOLVED


### PR DESCRIPTION
Reverts #968, reapplying #965, resolves #967. Per a GitHub search, it seems that the mixin conflict in question is [unique to Hexxy Searches For a Lost Cat in the Alps](https://github.com/search?q=%40WrapMethod+queueExecuteAndWrapIotas&type=code). The behavior of a single addon, especially one that is only used on one server, is not our responsibility, and alternatives to introducing a parameter are much hackier than they need to be.