### PR TITLE
Make the MishapInvalidIota lang fallback actually work

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInvalidIota.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInvalidIota.kt
@@ -26,10 +26,13 @@ class MishapInvalidIota(
 
     override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context): Component? {
         val perpKey = HexIotaTypes.REGISTRY.getKey(perpetrator.getType())
-        val perpDesc = Component.translatableWithFallback(
-            "hexcasting.iota.${perpKey}.desc",
-            "hexcasting.mishap.invalid_value.class.${perpKey?.getPath()}"
-        )
+        
+        // this translation key is preferred because it includes the namespace
+        var perpDesc = Component.translatableWithFallback("hexcasting.iota.${perpKey}.desc", "no desc found")
+        // for addons that don't implement the .desc key, grab the non-namespaced invalid_value key instead
+        if (perpDesc.getString() == "no desc found")
+            perpDesc = Component.translatable("hexcasting.mishap.invalid_value.class.${perpKey?.getPath()}")
+        
         return error(
             "invalid_value", expected, reverseIdx,
             perpDesc, perpetrator.display()


### PR DESCRIPTION
Exactly what it says in the title. Turns out `Component.translatableWithFallBack()` doesn't translate the fallback string and just uses it as a literal, so the current implementation of MishapInvalidIota doesn't properly fall back to the existing `invalid_value` key if the new `desc` key doesn't exist. This PR fixes that, and also adds some comments explaining why two different keys are being checked in the first place.