### PR TITLE
Remove log clutter on world load

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/PatternRegistryManifest.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/PatternRegistryManifest.java
@@ -57,9 +57,9 @@ public class PatternRegistryManifest {
             }
         }
 
-        HexAPI.LOGGER.info(("We're on the %s! " +
+        HexAPI.LOGGER.info(("We've loaded the pattern registry! " +
             "Loaded %d regular actions, %d per-world actions, and %d special handlers").formatted(
-            (overworld == null) ? "client" : "server", NORMAL_ACTION_LOOKUP.size(), perWorldActionCount,
+            NORMAL_ACTION_LOOKUP.size(), perWorldActionCount,
             IXplatAbstractions.INSTANCE.getSpecialHandlerRegistry().size()
         ));
     }

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/PatternRegistryManifest.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/PatternRegistryManifest.java
@@ -57,9 +57,9 @@ public class PatternRegistryManifest {
             }
         }
 
-        HexAPI.LOGGER.info(("We've loaded the pattern registry! " +
+        HexAPI.LOGGER.info(("We've loaded the pattern registry on the %s first! " +
             "Loaded %d regular actions, %d per-world actions, and %d special handlers").formatted(
-            NORMAL_ACTION_LOOKUP.size(), perWorldActionCount,
+            (overworld == null) ? "client" : "server", NORMAL_ACTION_LOOKUP.size(), perWorldActionCount,
             IXplatAbstractions.INSTANCE.getSpecialHandlerRegistry().size()
         ));
     }

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexClientInitializer.kt
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexClientInitializer.kt
@@ -27,6 +27,7 @@ import net.minecraft.world.level.block.entity.BlockEntityType
 import java.util.function.Function
 
 object FabricHexClientInitializer : ClientModInitializer {
+    private var patternRegistryIsProcessed: Boolean = false
     override fun onInitializeClient() {
         FabricPacketHandler.initClient()
 
@@ -41,7 +42,10 @@ object FabricHexClientInitializer : ClientModInitializer {
         }
         TooltipComponentCallback.EVENT.register(PatternTooltipComponent::tryConvert)
         ClientPlayConnectionEvents.JOIN.register { _, _, _ ->
-            PatternRegistryManifest.processRegistry(null)
+            if (!patternRegistryIsProcessed) {
+                PatternRegistryManifest.processRegistry(null)
+                patternRegistryIsProcessed = true
+            }
         }
 
         MouseScrollCallback.EVENT.register(ShiftScrollListener::onScrollInGameplay)

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexClientInitializer.kt
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexClientInitializer.kt
@@ -1,5 +1,7 @@
 package at.petrak.hexcasting.fabric
 
+import at.petrak.hexcasting.api.HexAPI
+
 import at.petrak.hexcasting.client.ClientTickCounter
 import at.petrak.hexcasting.client.RegisterClientStuff
 import at.petrak.hexcasting.client.ShiftScrollListener
@@ -42,7 +44,7 @@ object FabricHexClientInitializer : ClientModInitializer {
         }
         TooltipComponentCallback.EVENT.register(PatternTooltipComponent::tryConvert)
         ClientPlayConnectionEvents.JOIN.register { _, _, _ ->
-            if (!patternRegistryIsProcessed) {
+            if (patternRegistryIsProcessed) {
                 PatternRegistryManifest.processRegistry(null)
                 patternRegistryIsProcessed = true
             }

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexClientInitializer.kt
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexClientInitializer.kt
@@ -29,7 +29,6 @@ import net.minecraft.world.level.block.entity.BlockEntityType
 import java.util.function.Function
 
 object FabricHexClientInitializer : ClientModInitializer {
-    private var patternRegistryIsProcessed: Boolean = false
     override fun onInitializeClient() {
         FabricPacketHandler.initClient()
 
@@ -44,9 +43,9 @@ object FabricHexClientInitializer : ClientModInitializer {
         }
         TooltipComponentCallback.EVENT.register(PatternTooltipComponent::tryConvert)
         ClientPlayConnectionEvents.JOIN.register { _, _, _ ->
-            if (patternRegistryIsProcessed) {
+            if (!FabricHexInitializer.patternRegistryIsProcessed) {
                 PatternRegistryManifest.processRegistry(null)
-                patternRegistryIsProcessed = true
+                FabricHexInitializer.patternRegistryIsProcessed = true
             }
         }
 

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexInitializer.kt
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexInitializer.kt
@@ -71,6 +71,7 @@ object FabricHexInitializer : ModInitializer {
         RegisterMisc.register()
     }
 
+    private var patternRegistryIsProcessed: Boolean = false
     fun initListeners() {
         UseEntityCallback.EVENT.register(BrainsweepingEvents::interactWithBrainswept)
         VillagerConversionCallback.EVENT.register(BrainsweepingEvents::copyBrainsweepPostTransformation)
@@ -85,8 +86,12 @@ object FabricHexInitializer : ModInitializer {
             }
         }
 
+
         ServerLifecycleEvents.SERVER_STARTED.register { server ->
-            PatternRegistryManifest.processRegistry(server.overworld())
+            if (!patternRegistryIsProcessed) {
+                PatternRegistryManifest.processRegistry(server.overworld())
+                patternRegistryIsProcessed = true
+            }
         }
 
         ServerTickEvents.END_WORLD_TICK.register(PlayerPositionRecorder::updateAllPlayers)

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexInitializer.kt
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexInitializer.kt
@@ -71,7 +71,9 @@ object FabricHexInitializer : ModInitializer {
         RegisterMisc.register()
     }
 
-    private var patternRegistryIsProcessed: Boolean = false
+    // this global is for both server and client because PatternRegistryManifest.processRegistry
+    // doesn't have separate processing for each
+    internal var patternRegistryIsProcessed: Boolean = false
     fun initListeners() {
         UseEntityCallback.EVENT.register(BrainsweepingEvents::interactWithBrainswept)
         VillagerConversionCallback.EVENT.register(BrainsweepingEvents::copyBrainsweepPostTransformation)

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexClientInitializer.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexClientInitializer.java
@@ -39,6 +39,7 @@ public class ForgeHexClientInitializer {
     public static ItemColors GLOBAL_ITEM_COLORS;
     public static BlockColors GLOBAL_BLOCK_COLORS;
 
+    private static boolean patternRegistryIsProcessed = false;
     @SubscribeEvent
     public static void clientInit(FMLClientSetupEvent evt) {
         evt.enqueueWork(() -> {
@@ -50,8 +51,11 @@ public class ForgeHexClientInitializer {
 
         var evBus = MinecraftForge.EVENT_BUS;
 
-        evBus.addListener((ClientPlayerNetworkEvent.LoggingIn e) ->
-            PatternRegistryManifest.processRegistry(null));
+        evBus.addListener((ClientPlayerNetworkEvent.LoggingIn e) -> {
+            if (patternRegistryIsProcessed) return;
+            PatternRegistryManifest.processRegistry(null);
+            patternRegistryIsProcessed = true;
+        });
 
         evBus.addListener((RenderLevelStageEvent e) -> {
             if (e.getStage().equals(RenderLevelStageEvent.Stage.AFTER_PARTICLES)) {

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexClientInitializer.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexClientInitializer.java
@@ -39,7 +39,6 @@ public class ForgeHexClientInitializer {
     public static ItemColors GLOBAL_ITEM_COLORS;
     public static BlockColors GLOBAL_BLOCK_COLORS;
 
-    private static boolean patternRegistryIsProcessed = false;
     @SubscribeEvent
     public static void clientInit(FMLClientSetupEvent evt) {
         evt.enqueueWork(() -> {
@@ -52,9 +51,9 @@ public class ForgeHexClientInitializer {
         var evBus = MinecraftForge.EVENT_BUS;
 
         evBus.addListener((ClientPlayerNetworkEvent.LoggingIn e) -> {
-            if (patternRegistryIsProcessed) return;
+            if (ForgeHexInitializer.patternRegistryIsProcessed) return;
             PatternRegistryManifest.processRegistry(null);
-            patternRegistryIsProcessed = true;
+            ForgeHexInitializer.patternRegistryIsProcessed = true;
         });
 
         evBus.addListener((RenderLevelStageEvent e) -> {

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexInitializer.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexInitializer.java
@@ -159,6 +159,7 @@ public class ForgeHexInitializer {
         });
     }
 
+    private static boolean patternRegistryIsProcessed = false;
     private static void initListeners() {
         var modBus = getModEventBus();
         var evBus = MinecraftForge.EVENT_BUS;
@@ -225,8 +226,11 @@ public class ForgeHexInitializer {
             }
         });
 
-        evBus.addListener((ServerStartedEvent evt) ->
-            PatternRegistryManifest.processRegistry(evt.getServer().overworld()));
+        evBus.addListener((ServerStartedEvent evt) -> {
+            if (patternRegistryIsProcessed) return;
+            PatternRegistryManifest.processRegistry(evt.getServer().overworld());
+            patternRegistryIsProcessed = true;
+        });
 
         evBus.addListener((RegisterCommandsEvent evt) -> HexCommands.register(evt.getDispatcher()));
 

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexInitializer.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexInitializer.java
@@ -159,7 +159,9 @@ public class ForgeHexInitializer {
         });
     }
 
-    private static boolean patternRegistryIsProcessed = false;
+    // this global is for both server and client because PatternRegistryManifest.processRegistry
+    // doesn't have separate processing for each
+    protected static boolean patternRegistryIsProcessed = false;
     private static void initListeners() {
         var modBus = getModEventBus();
         var evBus = MinecraftForge.EVENT_BUS;


### PR DESCRIPTION
Don't process the pattern registry more than once, removing log clutter.