### PR TITLE
Fix Shepherd top iota not bool mishap translation key

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/circle/MishapBoolDirectrixNotBool.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/circle/MishapBoolDirectrixNotBool.kt
@@ -21,5 +21,5 @@ class MishapBoolDirectrixNotBool(
     }
 
     override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context): Component =
-        error("circle.bool_directrix_no_bool", pos.toShortString(), perpetrator.display())
+        error("circle.bool_directrix.no_bool", pos.toShortString(), perpetrator.display())
 }


### PR DESCRIPTION
It was using an underscore instead of the expected period