### PR TITLE
Add option to disable wobblyness of patterns on animated slates

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
@@ -51,12 +51,15 @@ public class HexConfig {
 
         boolean alwaysShowListCommas();
 
+        boolean staticActiveSlates();
+
         boolean DEFAULT_CTRL_TOGGLES_OFF_STROKE_ORDER = false;
         boolean DEFAULT_INVERT_SPELLBOOK_SCROLL = false;
         boolean DEFAULT_INVERT_ABACUS_SCROLL = false;
         double DEFAULT_GRID_SNAP_THRESHOLD = 0.5;
         boolean DEFAULT_CLICKING_TOGGLES_DRAWING = false;
         boolean DEFAULT_ALWAYS_SHOW_LIST_COMMAS = false;
+        boolean DEFAULT_STATIC_ACTIVE_SLATES = false;
     }
 
     public interface ServerConfigAccess {

--- a/Common/src/main/java/at/petrak/hexcasting/client/render/WorldlyPatternRenderHelpers.java
+++ b/Common/src/main/java/at/petrak/hexcasting/client/render/WorldlyPatternRenderHelpers.java
@@ -1,6 +1,7 @@
 package at.petrak.hexcasting.client.render;
 
 import at.petrak.hexcasting.api.casting.math.HexPattern;
+import at.petrak.hexcasting.api.mod.HexConfig;
 import at.petrak.hexcasting.common.blocks.akashic.BlockAkashicBookshelf;
 import at.petrak.hexcasting.common.blocks.akashic.BlockEntityAkashicBookshelf;
 import at.petrak.hexcasting.common.blocks.circles.BlockEntitySlate;
@@ -71,7 +72,11 @@ public class WorldlyPatternRenderHelpers {
         boolean isOnCeiling = bs.getValue(BlockSlate.ATTACH_FACE) == AttachFace.CEILING;
         int facing = bs.getValue(BlockSlate.FACING).get2DDataValue();
 
-        boolean wombly = bs.getValue(BlockSlate.ENERGIZED);
+        boolean energized = bs.getValue(BlockSlate.ENERGIZED);
+        boolean wombly = energized;
+        if (HexConfig.client().staticActiveSlates()) {
+            wombly = false;
+        }
 
         ps.pushPose();
 
@@ -93,7 +98,7 @@ public class WorldlyPatternRenderHelpers {
 
         renderPattern(pattern,
                 wombly ? WORLDLY_SETTINGS_WOBBLY : WORLDLY_SETTINGS,
-                wombly ? PatternColors.SLATE_WOBBLY_PURPLE_COLOR : PatternColors.DEFAULT_PATTERN_COLOR,
+                energized ? PatternColors.SLATE_WOBBLY_PURPLE_COLOR : PatternColors.DEFAULT_PATTERN_COLOR,
                 tile.getBlockPos().hashCode(), ps, buffer, normal, null, light, 1);
         ps.popPose();
     }

--- a/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
+++ b/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
@@ -355,6 +355,10 @@
           "": "Always Show List Commas",
           "@Tooltip": "Whether all iota types should be comma-separated when displayed in lists (by default, pattern iotas do not use commas)",
         },
+        staticActiveSlates: {
+          "": "Static patterned slates",
+          "@Tooltip": "Whether patterns on slates should always be rendered non-moving",
+        }
       },
       
       server: {

--- a/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
+++ b/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
@@ -356,8 +356,8 @@
           "@Tooltip": "Whether all iota types should be comma-separated when displayed in lists (by default, pattern iotas do not use commas)",
         },
         staticActiveSlates: {
-          "": "Static patterned slates",
-          "@Tooltip": "Whether patterns on slates should always be rendered non-moving",
+          "": "Static Active Slates",
+          "@Tooltip": "Whether patterns on active slates should be rendered without wobble (improves performance with lots of active slates)",
         }
       },
       

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
@@ -138,6 +138,8 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         private boolean clickingTogglesDrawing = DEFAULT_CLICKING_TOGGLES_DRAWING;
         @ConfigEntry.Gui.Tooltip
         private boolean alwaysShowListCommas = DEFAULT_ALWAYS_SHOW_LIST_COMMAS;
+        @ConfigEntry.Gui.Tooltip
+        private boolean staticActiveSlates = DEFAULT_STATIC_ACTIVE_SLATES;
 
         @Override
         public void validatePostLoad() throws ValidationException {
@@ -173,6 +175,9 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         public boolean alwaysShowListCommas() {
              return alwaysShowListCommas;
         }
+
+        @Override
+        public boolean staticActiveSlates() { return staticActiveSlates; }
     }
 
     @Config(name = "server")

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
@@ -85,6 +85,7 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
         private static ForgeConfigSpec.DoubleValue gridSnapThreshold;
         private static ForgeConfigSpec.BooleanValue clickingTogglesDrawing;
         private static ForgeConfigSpec.BooleanValue alwaysShowListCommas;
+        private static ForgeConfigSpec.BooleanValue staticActiveSlates;
 
         public Client(ForgeConfigSpec.Builder builder) {
             ctrlTogglesOffStrokeOrder = builder.comment(
@@ -107,6 +108,9 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
             alwaysShowListCommas = builder.comment(
                             "Whether all iota types should be comma-separated in lists (by default, pattern iotas don't use commas)")
                     .define("alwaysShowListCommas", DEFAULT_ALWAYS_SHOW_LIST_COMMAS);
+            staticActiveSlates = builder.comment(
+                            "Whether patterns on slates should always be rendered non-moving")
+                    .define("staticActiveSlates", DEFAULT_STATIC_ACTIVE_SLATES);
         }
 
         @Override
@@ -138,6 +142,9 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
         public boolean alwaysShowListCommas() {
             return alwaysShowListCommas.get();
         }
+
+        @Override
+        public boolean staticActiveSlates() { return staticActiveSlates.get(); }
     }
 
     public static class Server implements HexConfig.ServerConfigAccess {

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
@@ -109,7 +109,7 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
                             "Whether all iota types should be comma-separated in lists (by default, pattern iotas don't use commas)")
                     .define("alwaysShowListCommas", DEFAULT_ALWAYS_SHOW_LIST_COMMAS);
             staticActiveSlates = builder.comment(
-                            "Whether patterns on slates should always be rendered non-moving")
+                            "Whether patterns on active slates should be rendered without wobble (improves performance with lots of active slates)")
                     .define("staticActiveSlates", DEFAULT_STATIC_ACTIVE_SLATES);
         }
 


### PR DESCRIPTION
Rendering many active slates with patterns has a significant performance impact due to the wobble animation of the patterns, this adds a setting to disable that wobble.