### PR TITLE
Several tweaks for brainsweep sacrifice entity display

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/BrainsweepeeIngredient.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/BrainsweepeeIngredient.java
@@ -9,11 +9,11 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 
 // Partially based on:
 // https://github.com/SlimeKnights/Mantle/blob/1.18.2/src/main/java/slimeknights/mantle/recipe/ingredient/EntityIngredient.java
@@ -82,5 +82,14 @@ public abstract class BrainsweepeeIngredient {
     public static Component getModNameComponent(String namespace) {
         String mod = IXplatAbstractions.INSTANCE.getModName(namespace);
         return Component.literal(mod).withStyle(ChatFormatting.BLUE, ChatFormatting.ITALIC);
+    }
+
+    private static Map<EntityType<?>, Entity> cachedExampleEntity = new HashMap<>();
+    protected static Entity getCachedExampleEntity(EntityType<?> type, Level level) {
+        // don't cache for server levels (if any) to prevent wrong side
+        if (!level.isClientSide) {
+            return type.create(level);
+        }
+        return cachedExampleEntity.computeIfAbsent(type, t -> t.create(level));
     }
 }

--- a/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/BrainsweepeeIngredient.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/BrainsweepeeIngredient.java
@@ -37,12 +37,24 @@ public abstract class BrainsweepeeIngredient {
     public abstract void write(FriendlyByteBuf buf);
 
     /**
-     * For the benefit of showing to the client, return an example of the entity.
+     * For the benefit of showing to the client, return a list of example entities.
      * <p>
-     * Can return null in case someone did something stupid with a recipe
+     * Can return empty list in case someone did something stupid with a recipe
+     */
+    public abstract List<Entity> exampleEntities(Level level);
+
+    /**
+     * @deprecated Binary compatibility API. Use exampleEntities instead.
      */
     @Nullable
-    public abstract Entity exampleEntity(Level level);
+    @Deprecated
+    public final Entity exampleEntity(Level level) {
+        try {
+            return exampleEntities(level).iterator().next();
+        } catch (NoSuchElementException e) {
+            return null;
+        }
+    }
 
     public abstract Type ingrType();
 

--- a/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/EntityTagIngredient.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/EntityTagIngredient.java
@@ -70,9 +70,12 @@ public class EntityTagIngredient extends BrainsweepeeIngredient {
 
     @Override
     public Entity exampleEntity(Level level) {
-        var someEntityTys = BuiltInRegistries.ENTITY_TYPE.getTagOrEmpty(this.entityTypeTag).iterator();
-        if (someEntityTys.hasNext()) {
-            var someTy = someEntityTys.next();
+        var someEntityTysHolder = BuiltInRegistries.ENTITY_TYPE.getTag(this.entityTypeTag);
+        if (someEntityTysHolder.isEmpty()) return null;
+        var someEntityTys = someEntityTysHolder.get();
+        if (someEntityTys.size() > 0) {
+            long seconds = System.currentTimeMillis();
+            var someTy = someEntityTys.get((int) (seconds % someEntityTys.size()));
             return someTy.value().create(level);
         } else {
             return null;

--- a/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/EntityTagIngredient.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/EntityTagIngredient.java
@@ -76,7 +76,7 @@ public class EntityTagIngredient extends BrainsweepeeIngredient {
         if (someEntityTys.size() > 0) {
             long seconds = System.currentTimeMillis();
             var someTy = someEntityTys.get((int) (seconds % someEntityTys.size()));
-            return someTy.value().create(level);
+            return getCachedExampleEntity(someTy.value(), level);
         } else {
             return null;
         }

--- a/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/EntityTagIngredient.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/EntityTagIngredient.java
@@ -74,7 +74,7 @@ public class EntityTagIngredient extends BrainsweepeeIngredient {
         if (someEntityTysHolder.isEmpty()) return null;
         var someEntityTys = someEntityTysHolder.get();
         if (someEntityTys.size() > 0) {
-            long seconds = System.currentTimeMillis();
+            long seconds = System.currentTimeMillis() / 1000;
             var someTy = someEntityTys.get((int) (seconds % someEntityTys.size()));
             return getCachedExampleEntity(someTy.value(), level);
         } else {

--- a/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/EntityTagIngredient.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/EntityTagIngredient.java
@@ -1,6 +1,8 @@
 package at.petrak.hexcasting.common.recipe.ingredient.brainsweep;
 
 import com.google.gson.JsonObject;
+import java.util.Set;
+import java.util.stream.Collectors;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.core.Registry;
@@ -69,17 +71,14 @@ public class EntityTagIngredient extends BrainsweepeeIngredient {
     }
 
     @Override
-    public Entity exampleEntity(Level level) {
+    public List<Entity> exampleEntities(Level level) {
         var someEntityTysHolder = BuiltInRegistries.ENTITY_TYPE.getTag(this.entityTypeTag);
-        if (someEntityTysHolder.isEmpty()) return null;
+        if (someEntityTysHolder.isEmpty()) return List.of();
         var someEntityTys = someEntityTysHolder.get();
-        if (someEntityTys.size() > 0) {
-            long seconds = System.currentTimeMillis() / 1000;
-            var someTy = someEntityTys.get((int) (seconds % someEntityTys.size()));
-            return getCachedExampleEntity(someTy.value(), level);
-        } else {
-            return null;
-        }
+
+        return someEntityTys.stream()
+                .map(someTy -> getCachedExampleEntity(someTy.value(), level))
+                .toList();
     }
 
     @Override

--- a/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/EntityTypeIngredient.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/EntityTypeIngredient.java
@@ -43,7 +43,7 @@ public class EntityTypeIngredient extends BrainsweepeeIngredient {
 
     @Override
     public Entity exampleEntity(Level level) {
-        return this.entityType.create(level);
+        return getCachedExampleEntity(this.entityType, level);
     }
 
     @Override

--- a/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/EntityTypeIngredient.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/EntityTypeIngredient.java
@@ -1,6 +1,7 @@
 package at.petrak.hexcasting.common.recipe.ingredient.brainsweep;
 
 import com.google.gson.JsonObject;
+import java.util.Set;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.FriendlyByteBuf;
@@ -42,8 +43,8 @@ public class EntityTypeIngredient extends BrainsweepeeIngredient {
     }
 
     @Override
-    public Entity exampleEntity(Level level) {
-        return getCachedExampleEntity(this.entityType, level);
+    public List<Entity> exampleEntities(Level level) {
+        return List.of(getCachedExampleEntity(this.entityType, level));
     }
 
     @Override

--- a/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/VillagerIngredient.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/recipe/ingredient/brainsweep/VillagerIngredient.java
@@ -1,6 +1,7 @@
 package at.petrak.hexcasting.common.recipe.ingredient.brainsweep;
 
 import com.google.gson.JsonObject;
+import java.util.Set;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -53,7 +54,7 @@ public class VillagerIngredient extends BrainsweepeeIngredient {
     }
 
     @Override
-    public Entity exampleEntity(Level level) {
+    public List<Entity> exampleEntities(Level level) {
         var biome = Objects.requireNonNullElse(this.biome, VillagerType.PLAINS);
         var profession = Objects.requireNonNullElse(this.profession, VillagerProfession.TOOLSMITH);
         var tradeLevel = Math.min(this.minLevel, 1);
@@ -71,7 +72,7 @@ public class VillagerIngredient extends BrainsweepeeIngredient {
         var tag = new CompoundTag();
         out.save(tag);
 
-        return out;
+        return List.of(out);
     }
 
     @Override

--- a/Common/src/main/java/at/petrak/hexcasting/interop/patchouli/BrainsweepProcessor.java
+++ b/Common/src/main/java/at/petrak/hexcasting/interop/patchouli/BrainsweepProcessor.java
@@ -22,7 +22,7 @@ import java.util.List;
 public class BrainsweepProcessor implements IComponentProcessor {
 	private BrainsweepRecipe recipe;
 	@Nullable
-	private String exampleEntityString;
+	private List<IVariable> exampleEntityList;
 
 	@Override
 	public void setup(Level level, IVariableProvider vars) {
@@ -57,22 +57,28 @@ public class BrainsweepProcessor implements IComponentProcessor {
 			}
 
 			case "entity" -> {
-				if (this.exampleEntityString == null) {
-					var entity = this.recipe.entityIn().exampleEntity(Minecraft.getInstance().level);
-					if (entity == null) {
+				if (this.exampleEntityList == null) {
+					var entities = this.recipe.entityIn().exampleEntities(Minecraft.getInstance().level);
+					if (entities.isEmpty()) {
 						// oh dear
 						return null;
 					}
-					var bob = new StringBuilder();
-					bob.append(BuiltInRegistries.ENTITY_TYPE.getKey(entity.getType()));
 
-					var tag = new CompoundTag();
-					entity.save(tag);
-					bob.append(tag.toString());
-					this.exampleEntityString = bob.toString();
+					this.exampleEntityList = entities.stream().map(entity -> {
+						var bob = new StringBuilder();
+						bob.append(BuiltInRegistries.ENTITY_TYPE.getKey(entity.getType()));
+
+						var tag = new CompoundTag();
+						entity.save(tag);
+						bob.append(tag.toString());
+						return IVariable.wrap(bob.toString());
+					}).toList();
 				}
 
-				return IVariable.wrap(this.exampleEntityString);
+				//return IVariable.wrapList(this.exampleEntityList);
+				// patchouli does not currently support cycling entity displays
+				// https://github.com/VazkiiMods/Patchouli/issues/852
+				return this.exampleEntityList.get(0);
 			}
 			case "entityTooltip" -> {
 				Minecraft mc = Minecraft.getInstance();

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/interop/emi/BrainsweepeeEmiStack.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/interop/emi/BrainsweepeeEmiStack.java
@@ -5,6 +5,7 @@ import at.petrak.hexcasting.common.recipe.ingredient.brainsweep.BrainsweepeeIngr
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import dev.emi.emi.api.stack.EmiStack;
+import java.util.Set;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
@@ -15,6 +16,7 @@ import net.minecraft.resources.ResourceLocation;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import net.minecraft.world.entity.Entity;
 
 import static at.petrak.hexcasting.api.HexAPI.modLoc;
 import static at.petrak.hexcasting.client.render.RenderLib.renderEntity;
@@ -82,7 +84,12 @@ public class BrainsweepeeEmiStack extends EmiStack {
             Minecraft mc = Minecraft.getInstance();
             ClientLevel level = mc.level;
             if (level != null) {
-                var example = this.ingredient.exampleEntity(level);
+                var examples = this.ingredient.exampleEntities(level);
+                Entity example = null;
+                if (!examples.isEmpty()) {
+                    long seconds = System.currentTimeMillis() / 1000;
+                    example = examples.get((int) (seconds % examples.size()));
+                }
 
                 RenderSystem.enableBlend();
                 RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/interop/jei/BrainsweepRecipeCategory.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/interop/jei/BrainsweepRecipeCategory.java
@@ -17,6 +17,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -78,7 +79,12 @@ public class BrainsweepRecipeCategory implements IRecipeCategory<BrainsweepRecip
     public void draw(@NotNull BrainsweepRecipe recipe, @NotNull IRecipeSlotsView recipeSlotsView, @NotNull GuiGraphics graphics, double mouseX, double mouseY) {
         ClientLevel level = Minecraft.getInstance().level;
         if (level != null) {
-            var example = recipe.entityIn().exampleEntity(level);
+            var examples = recipe.entityIn().exampleEntities(level);
+            Entity example = null;
+            if (!examples.isEmpty()) {
+                long seconds = System.currentTimeMillis() / 1000;
+                example = examples.get((int) (seconds % examples.size()));
+            }
             if (example == null)
                 return;
 


### PR DESCRIPTION
- loop display every choices for tag ingredient
- cache them on client to prevent by-frame new instances