### PR TITLE
fix: packaged items should batch pattern packets like staff casting does

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/PackagedItemCastEnv.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/PackagedItemCastEnv.java
@@ -2,17 +2,14 @@ package at.petrak.hexcasting.api.casting.eval.env;
 
 import at.petrak.hexcasting.api.casting.eval.CastResult;
 import at.petrak.hexcasting.api.casting.eval.sideeffects.EvalSound;
-import at.petrak.hexcasting.api.casting.iota.PatternIota;
 import at.petrak.hexcasting.api.pigment.FrozenPigment;
 import at.petrak.hexcasting.common.lib.hex.HexEvalSounds;
-import at.petrak.hexcasting.common.msgs.MsgNewSpiralPatternsS2C;
 import at.petrak.hexcasting.xplat.IXplatAbstractions;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 
-import java.util.List;
 
-public class PackagedItemCastEnv extends PlayerBasedCastEnv {
+public class PackagedItemCastEnv extends PlayerBasedSpiralPatternCastEnv {
 
     protected EvalSound sound = HexEvalSounds.NOTHING;
 
@@ -24,16 +21,13 @@ public class PackagedItemCastEnv extends PlayerBasedCastEnv {
     public void postExecution(CastResult result) {
         super.postExecution(result);
 
-        if (result.component1() instanceof PatternIota patternIota) {
-            var packet = new MsgNewSpiralPatternsS2C(
-                    this.caster.getUUID(), List.of(patternIota.getPattern()), 140
-            );
-            IXplatAbstractions.INSTANCE.sendPacketToPlayer(this.caster, packet);
-            IXplatAbstractions.INSTANCE.sendPacketTracking(this.caster, packet);
-        }
-
         // TODO: how do we know when to actually play this sound?
         this.sound = this.sound.greaterOf(result.getSound());
+    }
+
+    @Override
+    public int getSpiralPatternDuration() {
+        return 140;
     }
 
     @Override

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/PlayerBasedCastEnv.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/PlayerBasedCastEnv.java
@@ -39,6 +39,10 @@ import java.util.function.Predicate;
 import static at.petrak.hexcasting.api.HexAPI.modLoc;
 import static at.petrak.hexcasting.api.utils.HexUtils.isOfTag;
 
+/**
+ * Player-based casting environment. Consider using {@link PlayerBasedSpiralPatternCastEnv} instead
+ * if executed patterns should be displayed in a spiral around the caster.
+ */
 public abstract class PlayerBasedCastEnv extends CastingEnvironment {
     public static final double DEFAULT_AMBIT_RADIUS = 32.0;
     private double ambitRadius;

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/PlayerBasedSpiralPatternCastEnv.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/PlayerBasedSpiralPatternCastEnv.java
@@ -22,6 +22,9 @@ public abstract class PlayerBasedSpiralPatternCastEnv extends PlayerBasedCastEnv
         super(caster, castingHand);
     }
 
+    /**
+     * Returns the duration (in ticks) that patterns should remain visible after being executed by the env.
+     */
     public abstract int getSpiralPatternDuration();
 
     @Override

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/PlayerBasedSpiralPatternCastEnv.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/PlayerBasedSpiralPatternCastEnv.java
@@ -1,0 +1,48 @@
+package at.petrak.hexcasting.api.casting.eval.env;
+
+import at.petrak.hexcasting.api.casting.eval.CastResult;
+import at.petrak.hexcasting.api.casting.eval.vm.CastingImage;
+import at.petrak.hexcasting.api.casting.iota.PatternIota;
+import at.petrak.hexcasting.api.casting.math.HexPattern;
+import at.petrak.hexcasting.common.msgs.MsgNewSpiralPatternsS2C;
+import at.petrak.hexcasting.xplat.IXplatAbstractions;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Variant of {@link PlayerBasedCastEnv} that tracks executed patterns and displays them in a spiral around the player
+ */
+public abstract class PlayerBasedSpiralPatternCastEnv extends PlayerBasedCastEnv {
+    private final Set<HexPattern> castPatterns = new HashSet<>();
+
+    public PlayerBasedSpiralPatternCastEnv(ServerPlayer caster, InteractionHand castingHand) {
+        super(caster, castingHand);
+    }
+
+    public abstract int getSpiralPatternDuration();
+
+    @Override
+    public void postExecution(CastResult result) {
+        super.postExecution(result);
+
+        if (result.component1() instanceof PatternIota patternIota) {
+            castPatterns.add(patternIota.getPattern());
+        }
+    }
+
+    @Override
+    public void postCast(CastingImage image) {
+        super.postCast(image);
+
+        var packet = new MsgNewSpiralPatternsS2C(
+                this.caster.getUUID(), castPatterns.stream().toList(), getSpiralPatternDuration()
+        );
+        IXplatAbstractions.INSTANCE.sendPacketToPlayer(this.caster, packet);
+        IXplatAbstractions.INSTANCE.sendPacketTracking(this.caster, packet);
+
+        castPatterns.clear();
+    }
+}

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/StaffCastEnv.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/env/StaffCastEnv.java
@@ -8,7 +8,6 @@ import at.petrak.hexcasting.api.casting.eval.ResolvedPattern;
 import at.petrak.hexcasting.api.casting.eval.vm.CastingImage;
 import at.petrak.hexcasting.api.casting.iota.PatternIota;
 import at.petrak.hexcasting.api.casting.math.HexCoord;
-import at.petrak.hexcasting.api.casting.math.HexPattern;
 import at.petrak.hexcasting.api.mod.HexStatistics;
 import at.petrak.hexcasting.api.pigment.FrozenPigment;
 import at.petrak.hexcasting.common.msgs.*;
@@ -21,14 +20,11 @@ import net.minecraft.world.phys.Vec3;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
-public class StaffCastEnv extends PlayerBasedCastEnv {
+public class StaffCastEnv extends PlayerBasedSpiralPatternCastEnv {
     private final InteractionHand castingHand;
 
-    private final Set<HexPattern> castPatterns = new HashSet<>();
     private int soundsPlayed = 0;
-
 
     public StaffCastEnv(ServerPlayer caster, InteractionHand castingHand) {
         super(caster, castingHand);
@@ -39,10 +35,6 @@ public class StaffCastEnv extends PlayerBasedCastEnv {
     @Override
     public void postExecution(CastResult result) {
         super.postExecution(result);
-
-        if (result.component1() instanceof PatternIota patternIota) {
-            castPatterns.add(patternIota.getPattern());
-        }
 
         // we always want to play this sound one at a time
         var sound = result.getSound().sound();
@@ -58,14 +50,12 @@ public class StaffCastEnv extends PlayerBasedCastEnv {
     public void postCast(CastingImage image) {
         super.postCast(image);
 
-        var packet = new MsgNewSpiralPatternsS2C(
-            this.caster.getUUID(), castPatterns.stream().toList(), Integer.MAX_VALUE
-        );
-        IXplatAbstractions.INSTANCE.sendPacketToPlayer(this.caster, packet);
-        IXplatAbstractions.INSTANCE.sendPacketTracking(this.caster, packet);
-
-        castPatterns.clear();
         soundsPlayed = 0;
+    }
+
+    @Override
+    public int getSpiralPatternDuration() {
+        return Integer.MAX_VALUE;
     }
 
     @Override

--- a/Common/src/main/java/at/petrak/hexcasting/common/items/magic/ItemPackagedHex.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/items/magic/ItemPackagedHex.java
@@ -131,14 +131,6 @@ public abstract class ItemPackagedHex extends ItemMediaHolder implements HexHold
         var vm = CastingVM.empty(ctx);
         var clientView = vm.queueExecuteAndWrapIotas(instrs, sPlayer.serverLevel());
 
-        var patterns = instrs.stream()
-                .filter(i -> i instanceof PatternIota)
-                .map(i -> ((PatternIota) i).getPattern())
-                .toList();
-        var packet = new MsgNewSpiralPatternsS2C(sPlayer.getUUID(), patterns, 140);
-        IXplatAbstractions.INSTANCE.sendPacketToPlayer(sPlayer, packet);
-        IXplatAbstractions.INSTANCE.sendPacketTracking(sPlayer, packet);
-
         boolean broken = breakAfterDepletion() && getMedia(stack) == 0;
 
         Stat<?> stat;


### PR DESCRIPTION
Previous behavior:
Casting with a packaged item results in the server sending one packet per evaluated pattern, causing network lag

Fixed behavior:
Casting with a packaged item will batch the patterns in a set and send it all in one packet at the end, like how the StaffCastEnv already does.

Closes #1026