### PR TITLE
fix: op consumption check should happen in CastingVM instead of PatternIota

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
@@ -59,6 +59,13 @@ class CastingVM(var image: CastingImage, val env: CastingEnvironment) {
                         resolutionType = ResolvedPatternType.ERRORED,
                         sound = HexEvalSounds.MISHAP,
                     )
+                } else if (result.newData != null && result.newData.opsConsumed > env.maxOpCount()) {
+                    result.copy(
+                        newData = null,
+                        sideEffects = listOf(OperatorSideEffect.DoMishap(MishapEvalTooMuch(), Mishap.Context(null, null))),
+                        resolutionType = ResolvedPatternType.ERRORED,
+                        sound = HexEvalSounds.MISHAP,
+                    )
                 } else {
                     result
                 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/PatternIota.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/PatternIota.java
@@ -108,10 +108,6 @@ public class PatternIota extends Iota {
                     continuation
             );
 
-            if (result.getNewImage().getOpsConsumed() > vm.getEnv().maxOpCount()) {
-                throw new MishapEvalTooMuch();
-            }
-
             var cont2 = result.getNewContinuation();
             // TODO parens also break prescience
             var sideEffects = result.getSideEffects();


### PR DESCRIPTION
Currently, the op limit check happens in `PatternIota.execute` rather than in `CastingVM`. This means that executable non-pattern iota and certain continuation frames can go past the op limit, and in extreme cases, hang the server thread indefinitely. (The latter case is currently possible with addons, and the most natural fix is moving the check to `CastingVM`.)

This PR moves the op limit check to the same place the stack limit is checked. Player-observable behavior should remain the same.