### PR TITLE
Update Gradle, Kotlin, and Loom to support Inline 1.2.2

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,7 +60,7 @@ jobs:
             mc-runtime-test: fabric
             fabric-api: 0.87.0
             dependencies: >-
-              'https://cdn.modrinth.com/data/Ha28R6CL/versions/vlhvI5Li/fabric-language-kotlin-1.10.18%2Bkotlin.1.9.22.jar'
+              'https://cdn.modrinth.com/data/Ha28R6CL/versions/LcgnDDmT/fabric-language-kotlin-1.13.7%2Bkotlin.2.2.21.jar'
               'https://cdn.modrinth.com/data/9s6osm5g/versions/s7VTKfLA/cloth-config-11.1.106-fabric.jar'
               'https://cdn.modrinth.com/data/TZo2wHFe/versions/dabyDTwJ/paucal-0.6.0%2B1.20.1-fabric.jar'
               'https://cdn.modrinth.com/data/fin1PX4m/versions/n7VmkBLu/inline-fabric-1.20.1-1.2.2.jar'
@@ -72,7 +72,7 @@ jobs:
             mc-runtime-test: lexforge
             fabric-api: none
             dependencies: >-
-              'https://cdn.modrinth.com/data/ordsPcFz/versions/9j6YaPp2/kotlinforforge-4.10.0-all.jar'
+              'https://cdn.modrinth.com/data/ordsPcFz/versions/Zsh14XeQ/kotlinforforge-4.12.0-all.jar'
               'https://cdn.modrinth.com/data/9s6osm5g/versions/JoLgnJ0G/cloth-config-11.1.106-forge.jar'
               'https://cdn.modrinth.com/data/TZo2wHFe/versions/HyBiJPtT/paucal-0.6.0%2B1.20.1-forge.jar'
               'https://cdn.modrinth.com/data/fin1PX4m/versions/H1jsvy53/inline-forge-1.20.1-1.2.2.jar'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,7 +63,7 @@ jobs:
               'https://cdn.modrinth.com/data/Ha28R6CL/versions/vlhvI5Li/fabric-language-kotlin-1.10.18%2Bkotlin.1.9.22.jar'
               'https://cdn.modrinth.com/data/9s6osm5g/versions/s7VTKfLA/cloth-config-11.1.106-fabric.jar'
               'https://cdn.modrinth.com/data/TZo2wHFe/versions/dabyDTwJ/paucal-0.6.0%2B1.20.1-fabric.jar'
-              'https://cdn.modrinth.com/data/fin1PX4m/versions/oUAVXW1N/inline-fabric-1.20.1-1.1.1.jar'
+              'https://cdn.modrinth.com/data/fin1PX4m/versions/n7VmkBLu/inline-fabric-1.20.1-1.2.2.jar'
               'https://cdn.modrinth.com/data/K01OU20C/versions/HykM2Qyv/cardinal-components-api-5.2.1.jar'
               'https://cdn.modrinth.com/data/nU0bVIaL/versions/Y6tuH1cn/Patchouli-1.20.1-84-FABRIC.jar'
               'https://cdn.modrinth.com/data/mOgUt4GM/versions/zv46i3PW/modmenu-7.1.0.jar'
@@ -75,7 +75,7 @@ jobs:
               'https://cdn.modrinth.com/data/ordsPcFz/versions/9j6YaPp2/kotlinforforge-4.10.0-all.jar'
               'https://cdn.modrinth.com/data/9s6osm5g/versions/JoLgnJ0G/cloth-config-11.1.106-forge.jar'
               'https://cdn.modrinth.com/data/TZo2wHFe/versions/HyBiJPtT/paucal-0.6.0%2B1.20.1-forge.jar'
-              'https://cdn.modrinth.com/data/fin1PX4m/versions/U3ktiRdL/inline-forge-1.20.1-1.1.1.jar'
+              'https://cdn.modrinth.com/data/fin1PX4m/versions/H1jsvy53/inline-forge-1.20.1-1.2.2.jar'
               'https://cdn.modrinth.com/data/40FYwb4z/versions/fs9CeXYZ/caelus-forge-3.1.0%2B1.20.jar'
               'https://cdn.modrinth.com/data/nU0bVIaL/versions/JMtc0mTS/Patchouli-1.20.1-84-FORGE.jar'
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Fixed a crash loop when trying to generate a creative-mode ancient scroll for a Great Spell whose per-world pattern hasn't been calculated yet, by Robotgiggle in [992](https://github.com/FallingColors/HexMod/pull/992).
 
+### Internal
+
+- The mod now uses Fabric Loom 1.9, Gradle 8.11, and Kotlin 2.0.20, by Robotgiggle in [#1043](https://github.com/FallingColors/HexMod/pull/1043).
+- Updated Inline dependency from 1.0.1 to 1.2.2, by Robotgiggle in [#1043](https://github.com/FallingColors/HexMod/pull/1043).
+
 ## `0.11.3` - 2025-11-22
 
 ### Added

--- a/Common/src/main/java/at/petrak/hexcasting/interop/inline/InlineHexClient.java
+++ b/Common/src/main/java/at/petrak/hexcasting/interop/inline/InlineHexClient.java
@@ -10,9 +10,9 @@ public class InlineHexClient {
         InlineClientAPI.INSTANCE.addMatcher(HexPatternMatcher.INSTANCE);
         InlineClientAPI.INSTANCE.addRenderer(InlinePatternRenderer.INSTANCE);
 
-        ItemOverlayRenderer.registerRenderer(HexItems.SCROLL_LARGE, HexPatternOverlayRenderer.SCROLL_RENDERER);
-        ItemOverlayRenderer.registerRenderer(HexItems.SCROLL_MEDIUM, HexPatternOverlayRenderer.SCROLL_RENDERER);
-        ItemOverlayRenderer.registerRenderer(HexItems.SCROLL_SMOL, HexPatternOverlayRenderer.SCROLL_RENDERER);
-        ItemOverlayRenderer.registerRenderer(HexItems.SLATE, HexPatternOverlayRenderer.SLATE_RENDERER);
+        ItemOverlayRenderer.addRenderer(HexItems.SCROLL_LARGE, HexPatternOverlayRenderer.SCROLL_RENDERER);
+        ItemOverlayRenderer.addRenderer(HexItems.SCROLL_MEDIUM, HexPatternOverlayRenderer.SCROLL_RENDERER);
+        ItemOverlayRenderer.addRenderer(HexItems.SCROLL_SMOL, HexPatternOverlayRenderer.SCROLL_RENDERER);
+        ItemOverlayRenderer.addRenderer(HexItems.SLATE, HexPatternOverlayRenderer.SLATE_RENDERER);
     }
 }

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version "1.6-SNAPSHOT"
+    id 'fabric-loom' version "1.9+"
     id "at.petra-k.pkpcpbp.PKSubprojPlugin"
 }
 
@@ -20,7 +20,7 @@ pkSubproj {
         "paucal:dabyDTwJ", // 0.6.0-fabric
         "patchouli:1.20.1-80-fabric",
         "fabric-language-kotlin:1.9.4+kotlin.1.8.21",
-        "inline:1.20.1-1.1.1-fabric",
+        "inline:1.20.1-1.2.2-fabric",
         "cloth-config:11.1.106+fabric",
         "cardinal-components-api:5.2.1",
         "fabric-api:0.84.0+1.20.1",

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -19,7 +19,7 @@ pkSubproj {
     modrinthDependencies([
         "paucal:dabyDTwJ", // 0.6.0-fabric
         "patchouli:1.20.1-80-fabric",
-        "fabric-language-kotlin:1.9.4+kotlin.1.8.21",
+        "fabric-language-kotlin:1.13.7+kotlin.2.2.21",
         "inline:1.20.1-1.2.2-fabric",
         "cloth-config:11.1.106+fabric",
         "cardinal-components-api:5.2.1",

--- a/Fabric/gradle.properties
+++ b/Fabric/gradle.properties
@@ -2,7 +2,7 @@ platform=fabric
 
 fabricVersion=0.85.0+1.20.1
 fabricLoaderVersion=0.14.21
-fabricLanguageKotlinVersion=1.9.4+kotlin.1.8.21
+fabricLanguageKotlinVersion=1.13.7+kotlin.2.2.21
 
 # These are all included
 cardinalComponentsVersion=5.2.1

--- a/Fabric/gradle.properties
+++ b/Fabric/gradle.properties
@@ -1,7 +1,7 @@
 platform=fabric
 
-fabricVersion=0.85.0+1.20.1
-fabricLoaderVersion=0.14.21
+fabricVersion=0.92.8+1.20.1
+fabricLoaderVersion=0.19.2
 fabricLanguageKotlinVersion=1.13.7+kotlin.2.2.21
 
 # These are all included

--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -50,7 +50,7 @@
     "java": ">=17",
     "fabricloader": ">=0.14",
     "fabric": ">=0.84",
-    "fabric-language-kotlin": ">=1.9.4+kotlin.1.8.21",
+    "fabric-language-kotlin": ">=1.13.7+kotlin.2.2.21",
     "cardinal-components-base": "~5.2.1",
     "cardinal-components-entity": "~5.2.1",
     "cardinal-components-item": "~5.2.1",

--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -58,7 +58,7 @@
     "paucal": ">=0.6.0-pre <0.7.0",
     "cloth-config": "11.1.*",
     "patchouli": ">=1.20.1-80",
-    "inline": ">=1.20.1-1.1.1"
+    "inline": ">=1.20.1-1.2.2"
   },
   "suggests": {
     "pehkui": ">=3.7.6",

--- a/Forge/build.gradle
+++ b/Forge/build.gradle
@@ -37,7 +37,7 @@ pkSubproj {
         "paucal:HyBiJPtT", // 0.6.0-forge
         "patchouli:1.20.1-80-forge",
         "caelus:3.1.0+1.20",
-        "inline:1.20.1-1.1.1-forge",
+        "inline:1.20.1-1.2.2-forge",
     ])
 }
 

--- a/Forge/gradle.properties
+++ b/Forge/gradle.properties
@@ -2,7 +2,7 @@ platform=forge
 
 forgeVersion=47.1.47
 
-kotlinForForgeVersion=4.3.0
+kotlinForForgeVersion=4.12.0
 
 curiosVersion=5.2.0-beta.3
 caelusVersion=3.1.0+1.20

--- a/Forge/src/main/resources/META-INF/mods.toml
+++ b/Forge/src/main/resources/META-INF/mods.toml
@@ -52,6 +52,6 @@ side = "BOTH"
 [[dependencies.hexcasting]]
 modId = "inline"
 mandatory = true
-versionRange = "[1.20.1-1.1.1,)"
+versionRange = "[1.20.1-1.2.2,)"
 ordering = "NONE"
 side = "BOTH"

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
     // This needs to be in the root
     // https://github.com/FabricMC/fabric-loom/issues/612#issuecomment-1198444120
     // Also it looks like property lookups don't work this early
-    id 'fabric-loom' version '1.6-SNAPSHOT' apply false
+    id 'fabric-loom' version '1.9+' apply false
 
     id("at.petra-k.pkpcpbp.PKPlugin") version "0.2.0-pre-104"
     id("at.petra-k.pkpcpbp.PKSubprojPlugin") version "0.2.0-pre-104" apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ modName=Hex Casting
 jetbrainsAnnotationsVersion=23.0.0
 
 minecraftVersion=1.20.1
-kotlinVersion=2.2.20
+kotlinVersion=2.2.21
 modVersion=0.11.3
 
 # this is the version published to modrinth/cf i swear

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ modName=Hex Casting
 jetbrainsAnnotationsVersion=23.0.0
 
 minecraftVersion=1.20.1
-kotlinVersion=1.7.20
+kotlinVersion=2.0.20
 modVersion=0.11.3
 
 # this is the version published to modrinth/cf i swear
@@ -19,5 +19,5 @@ patchouliVersion=83
 jeiVersion=15.0.0.12
 pehkuiVersion=3.7.7
 
-inlineVersion=1.1.1
+inlineVersion=1.2.2
 clothConfigVersion=11.1.106

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ paucalVersion=0.6.0-pre-118
 patchouliVersion=83
 
 jeiVersion=15.0.0.12
-pehkuiVersion=3.7.7
+pehkuiVersion=3.8.2
 
 inlineVersion=1.2.2
 clothConfigVersion=11.1.106

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ modName=Hex Casting
 jetbrainsAnnotationsVersion=23.0.0
 
 minecraftVersion=1.20.1
-kotlinVersion=2.0.20
+kotlinVersion=2.2.20
 modVersion=0.11.3
 
 # this is the version published to modrinth/cf i swear

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The current implementation of the pattern overlay feature added in #879 relies on a method in Inline that was renamed in the 1.2.0 update. Thus, if anyone uses a version of Inline beyond that point with the current version of hex, it will break. This PR updates hex's Inline dependency to the latest version and updates the relevant methods to their new names to prevent that from happening, and also updates a bunch of core libraries which are required for the new Inline version.

Note that if this PR does _not_ get merged before the 0.11.4 release, we should instead change the Inline dependency in `fabric.mod.json` (fabric) and `mods.toml` (forge) to explicitly exclude Inline versions 1.2.0 and onwards.

Also note that the new Kotlin version (2.2.21) now gives a bunch of warnings about the use of public `copy()` methods on data classes with private constructors, since that functionality will be removed in future versions of Kotlin. More info can be found [here](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-consistent-copy-visibility/) and [here](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-exposed-copy-visibility/).