### PR TITLE
Cache Slate Search results

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/block/circle/BlockCircleComponent.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/block/circle/BlockCircleComponent.java
@@ -4,13 +4,24 @@ import at.petrak.hexcasting.api.casting.circles.ICircleComponent;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+import static at.petrak.hexcasting.api.casting.circles.CircleExecutionState.CACHE;
 
 // Convenience impl of ICircleComponent
 public abstract class BlockCircleComponent extends Block implements ICircleComponent {
@@ -26,6 +37,27 @@ public abstract class BlockCircleComponent extends Block implements ICircleCompo
         world.setBlockAndUpdate(pos, newState);
 
         return newState;
+    }
+
+    @Override
+    public void destroy(@NotNull LevelAccessor world, @NotNull BlockPos blockPos, @NotNull BlockState blockState) {
+        // spaghet
+        for (Map.Entry<BlockPos, AABB> entry : CACHE.entrySet()) {
+            Vec3 location = blockPos.getCenter();
+            if (!entry.getValue().contains(location)) {continue;}
+            CACHE.remove(entry.getKey());
+        }
+    }
+
+    @Override
+    public void setPlacedBy(Level level, BlockPos blockPos, BlockState bs, @Nullable LivingEntity entity, ItemStack stack) {
+        for (Map.Entry<BlockPos, AABB> entry : CACHE.entrySet()) {
+            Vec3 location = blockPos.getCenter();
+            AABB aabb = entry.getValue();
+            if (!aabb.contains(location)) {continue;}
+            if (aabb.distanceToSqr(location) > 0.250009) {continue;}
+            CACHE.remove(entry.getKey());
+        }
     }
 
     @Override

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/ActionUtils.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/ActionUtils.kt
@@ -2,6 +2,7 @@
 
 package at.petrak.hexcasting.api.casting
 
+import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
 import at.petrak.hexcasting.api.casting.iota.*
 import at.petrak.hexcasting.api.casting.math.HexPattern
 import at.petrak.hexcasting.api.casting.mishaps.MishapInvalidIota

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/CircleExecutionState.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/CircleExecutionState.java
@@ -26,8 +26,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static at.petrak.hexcasting.api.HexAPI.LOGGER;
-
 /**
  * See {@link BlockEntityAbstractImpetus}, this is what's stored in it
  */
@@ -126,7 +124,6 @@ public class CircleExecutionState {
         }
 
         if (CACHE.containsKey(impetusPos)) {
-            LOGGER.info("Cache hit!");
             final AABB bounds = CACHE.get(impetusPos);
             BlockPos greater = new BlockPos((int) bounds.maxX, (int) bounds.maxY, (int) bounds.maxZ);
             BlockPos lesser = new BlockPos((int) bounds.minX, (int) bounds.minY, (int) bounds.minZ);
@@ -187,7 +184,6 @@ public class CircleExecutionState {
 
         AABB aabb = new AABB(positiveBlock.move(1,1,1), negativeBlock);
 
-        LOGGER.info("Cached for {}.",impetusPos);
         CACHE.put(impetusPos, aabb);
 
         return new Result.Ok<>(

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/CircleExecutionState.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/CircleExecutionState.java
@@ -24,6 +24,9 @@ import net.minecraft.world.phys.AABB;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static at.petrak.hexcasting.api.HexAPI.LOGGER;
 
 /**
  * See {@link BlockEntityAbstractImpetus}, this is what's stored in it
@@ -41,6 +44,9 @@ public class CircleExecutionState {
         TAG_REACHED_NUMBER = "reached_slate",
         TAG_POSITIVE_POS = "positive_pos",
         TAG_NEGATIVE_POS = "negative_pos";
+
+    // A cache for reusing previous searches. Invalidated when ICircleComponents are broken within the AABB.
+    public static final Map<BlockPos, AABB> CACHE = new ConcurrentHashMap<>();
 
     public final BlockPos impetusPos;
     public final Direction impetusDir;
@@ -107,6 +113,32 @@ public class CircleExecutionState {
         var positiveBlock = impetusPos.mutable();
         var negativeBlock = impetusPos.mutable();
         var lastBlockPos = impetusPos.mutable();
+        var reachedPositions = new HashSet<BlockPos>();
+        reachedPositions.add(impetus.getBlockPos());
+
+        FrozenPigment colorizer = null;
+        UUID casterUUID;
+        if (caster == null) {
+            casterUUID = null;
+        } else {
+            colorizer = HexAPI.instance().getColorizer(caster);
+            casterUUID = caster.getUUID();
+        }
+
+        if (CACHE.containsKey(impetusPos)) {
+            LOGGER.info("Cache hit!");
+            final AABB bounds = CACHE.get(impetusPos);
+            BlockPos greater = new BlockPos((int) bounds.maxX, (int) bounds.maxY, (int) bounds.maxZ);
+            BlockPos lesser = new BlockPos((int) bounds.minX, (int) bounds.minY, (int) bounds.minZ);
+
+            return new Result.Ok<>(
+                    new CircleExecutionState(
+                            impetus.getBlockPos(), impetus.getStartDirection(), reachedPositions,
+                            impetusPos.offset(impetus.getStartDirection().getNormal()), impetus.getStartDirection(),
+                            new CastingImage(), casterUUID, colorizer, 0L, greater, lesser
+                    )
+            );
+        }
 
         while (!todo.isEmpty()) {
             var pair = todo.pop();
@@ -133,6 +165,7 @@ public class CircleExecutionState {
                 negativeBlock.setZ(Math.min(herePos.getZ(), negativeBlock.getZ()));
                 // it's new
                 var outs = cmp.possibleExitDirections(herePos, hereBs, level);
+
                 for (var out : outs) {
                     todo.add(Pair.of(out, herePos.relative(out)));
                 }
@@ -152,17 +185,11 @@ public class CircleExecutionState {
             return new Result.Err<>(lastBlockPos);
         }
 
-        var reachedPositions = new HashSet<BlockPos>();
-        reachedPositions.add(impetus.getBlockPos());
+        AABB aabb = new AABB(positiveBlock.move(1,1,1), negativeBlock);
 
-        FrozenPigment colorizer = null;
-        UUID casterUUID;
-        if (caster == null) {
-            casterUUID = null;
-        } else {
-            colorizer = HexAPI.instance().getColorizer(caster);
-            casterUUID = caster.getUUID();
-        }
+        LOGGER.info("Cached for {}.",impetusPos);
+        CACHE.put(impetusPos, aabb);
+
         return new Result.Ok<>(
             new CircleExecutionState(impetus.getBlockPos(), impetus.getStartDirection(),
                 reachedPositions, impetus.getBlockPos().offset(impetus.getStartDirection().getNormal()),


### PR DESCRIPTION
Spell circles' slate search can take time to execute, and caching isn't expensive, so I figured I'd quickly implement caching. This was thrown together pretty quickly, and I'm open to any and all feedback you can give.
