### PR TITLE
Fix Jenkins build for 1.21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 pipeline {
     agent any
     tools {
-        jdk "jdk-17.0.1"
+        jdk "jdk-21.0.5"
     }
     environment {
         discordWebhook = credentials('discordWebhook')
@@ -66,7 +66,7 @@ pipeline {
     post {
         always {
             archiveArtifacts 'Common/build/libs/**.jar'
-            archiveArtifacts 'Forge/build/libs/**.jar'
+            archiveArtifacts 'NeoForge/build/libs/**.jar'
             archiveArtifacts 'Fabric/build/libs/**.jar'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 pipeline {
     agent any
     tools {
-        jdk "jdk-21.0.5"
+        jdk "jdk-21"
     }
     environment {
         discordWebhook = credentials('discordWebhook')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
     post {
         always {
             archiveArtifacts 'Common/build/libs/**.jar'
-            archiveArtifacts 'NeoForge/build/libs/**.jar'
+            archiveArtifacts 'Neoforge/build/libs/**.jar'
             archiveArtifacts 'Fabric/build/libs/**.jar'
         }
     }


### PR DESCRIPTION
Fixes the build failures in Jenkins for the 1.21 branch.

Passing build: https://ci.blamejared.com/job/petrakat/job/Hexcasting/job/1.21-fix-jenkins/3/