### PR TITLE
Check for null pattern when generating loot scrolls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Fixed a crash loop when trying to generate a creative-mode ancient scroll for a Great Spell whose per-world pattern hasn't been calculated yet ([#992](https://github.com/FallingColors/HexMod/pull/992)) @Robotgiggle
+- Fixed a crash when trying to generate a loot scroll for a Great Spell whose per-world pattern hasn't been calculated yet ([#1079](https://github.com/FallingColors/HexMod/pull/1079)) @Robotgiggle
 - Fixed Create Water and Create Lava causing the "position is forbidden to you" mishap when the position is actually just out of ambit ([#1029](https://github.com/FallingColors/HexMod/pull/1029)) @pythonmcpi
 - Fixed a broken translation key on the error message from a Shepherd Directrix ([#1013](https://github.com/FallingColors/HexMod/pull/1013)) @Teal-Wolf-25-v2
 - Fixed the log spam caused by double pattern registration when joining a world ([#999](https://github.com/FallingColors/HexMod/pull/999)) @Real-Luxof

--- a/Common/src/main/java/at/petrak/hexcasting/common/loot/AddPerWorldPatternToScrollFunc.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/loot/AddPerWorldPatternToScrollFunc.java
@@ -1,5 +1,6 @@
 package at.petrak.hexcasting.common.loot;
 
+import at.petrak.hexcasting.api.HexAPI;
 import at.petrak.hexcasting.api.casting.ActionRegistryEntry;
 import at.petrak.hexcasting.api.mod.HexTags;
 import at.petrak.hexcasting.api.utils.HexUtils;
@@ -48,8 +49,15 @@ public class AddPerWorldPatternToScrollFunc extends LootItemConditionalFunction 
             }
         }
         var patternKey = perWorldKeys.get(rand.nextInt(perWorldKeys.size()));
+        var patternID = patternKey.location().toString();
         var pat = PatternRegistryManifest.getCanonicalStrokesPerWorld(patternKey, overworld);
-        NBTHelper.putString(stack, ItemScroll.TAG_OP_ID, patternKey.location().toString());
+        if (pat == null) {
+            HexAPI.LOGGER.error("No per-world pattern found for action " + patternID + " while generating loot scroll! " +
+                                "Try running '/hexcasting recalcPatterns' to generate the patterns for this world.");
+            NBTHelper.putString(stack, ItemScroll.TAG_RECALC_WARNING, patternID);
+            return stack;
+        }
+        NBTHelper.putString(stack, ItemScroll.TAG_OP_ID, patternID);
         NBTHelper.put(stack, ItemScroll.TAG_PATTERN, pat.serializeToNBT());
         return stack;
     }

--- a/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
+++ b/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
@@ -603,7 +603,7 @@
         needs_purchase: "Purchase to show pattern",
         pattern_not_loaded: "Place in inventory to load pattern",
         "recalc_warning.line1": "The per-world pattern for %s has not been calculated yet!",
-        "recalc_warning.line2": "Please run /hexcasting recalcPatterns, then grab a new scroll.",
+        "recalc_warning.line2": "Please run /hexcasting recalcPatterns, then get a new scroll.",
       },
       
       abacus: {


### PR DESCRIPTION
Implements the same null-check used on creative scrolls for loot scroll generation, along with logging an error. Should fix #944, though I'm not sure what was causing that crash to happen on chunkload rather than on loot generation.

<img width="701" height="66" alt="image" src="https://github.com/user-attachments/assets/233cc6c5-0edc-4514-a06e-00417274df9c" />
