### PR TITLE
Fix thoth accumulator

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/FrameForEach.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/FrameForEach.kt
@@ -56,7 +56,7 @@ data class FrameForEach(
         level: ServerLevel,
         harness: CastingVM
     ): CastResult {
-        // If this isn't the very first Thoth step (i.e. no Thoth computations run yet)...
+        // If this is the very first Thoth step (i.e. no Thoth computations run yet)...
         val (stack, newAcc) = if (baseStack == null) {
             // init stack to the harness stack...
             harness.image.stack.toList() to immutableAcc
@@ -76,7 +76,7 @@ data class FrameForEach(
             Triple(data.car, harness.image.withUsedOp(), cont2)
         } else {
             // Else, dump our final list onto the stack.
-            Triple(ListIota(immutableAcc), harness.image, continuation)
+            Triple(ListIota(newAcc), harness.image, continuation)
         }
         val tStack = stack.toMutableList()
         tStack.add(stackTop)


### PR DESCRIPTION
Fixes #1085. Now that the thoth accumulator is immutable and operations that previously updated it return a new instance instead, we need to actually return that new instance at the end of the thoth instead of returning the old unmodified one.

Also, the comment on line 59 was describing the wrong case, so I fixed it.