### PR TITLE
Revert "Spell-list comma config toggle"

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/ListIota.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/ListIota.java
@@ -4,7 +4,6 @@ import at.petrak.hexcasting.api.casting.SpellList;
 import at.petrak.hexcasting.api.utils.HexUtils;
 import at.petrak.hexcasting.api.utils.TreeList;
 import at.petrak.hexcasting.common.lib.hex.HexIotaTypes;
-import at.petrak.hexcasting.api.mod.HexConfig;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -142,8 +141,7 @@ public class ListIota extends Iota {
                     var nextType = IotaType.getTypeFromTag(HexUtils.downcast(list.get(i+1), CompoundTag.TYPE));
                     var thisIotaNeedsComma = thisType == null || thisType.usesListCommas();
                     var nextIotaNeedsComma = nextType == null || nextType.usesListCommas();
-                    var alwaysShowCommas = HexConfig.client() != null && HexConfig.client().alwaysShowListCommas();
-                    if (thisIotaNeedsComma || nextIotaNeedsComma || alwaysShowCommas)
+                    if (thisIotaNeedsComma || nextIotaNeedsComma)
                         out.append(", ");
                 }
             }

--- a/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
@@ -51,8 +51,6 @@ public class HexConfig {
 
         boolean clickingTogglesDrawing();
 
-        boolean alwaysShowListCommas();
-
         boolean advancedTooltipsShowsIotaNBT();
       
         boolean staticActiveSlates();
@@ -63,7 +61,6 @@ public class HexConfig {
         boolean DEFAULT_INVERT_ABACUS_SCROLL = false;
         double DEFAULT_GRID_SNAP_THRESHOLD = 0.5;
         boolean DEFAULT_CLICKING_TOGGLES_DRAWING = false;
-        boolean DEFAULT_ALWAYS_SHOW_LIST_COMMAS = false;
         boolean DEFAULT_ADVANCED_TOOLTIPS_SHOWS_IOTA_NBT = false;
         boolean DEFAULT_STATIC_ACTIVE_SLATES = false;
     }

--- a/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
+++ b/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
@@ -364,10 +364,6 @@
           "": "Clicking Toggles Drawing",
           "@Tooltip": "Whether you click to start and stop drawing instead of clicking and dragging to draw",
         },
-        alwaysShowListCommas: {
-          "": "Always Show List Commas",
-          "@Tooltip": "Whether all iota types should be comma-separated when displayed in lists (by default, pattern iotas do not use commas)",
-        },
         advancedTooltipsShowsIotaNBT: {
           "": "Advanced Tooltips Shows Iota NBT",
           "@Tooltip": "Whether enabling advanced tooltips (F3+H) should display the full NBT of iotas stored in items like foci and spellbooks",

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
@@ -138,8 +138,6 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         @ConfigEntry.Gui.Tooltip
         private boolean clickingTogglesDrawing = DEFAULT_CLICKING_TOGGLES_DRAWING;
         @ConfigEntry.Gui.Tooltip
-        private boolean alwaysShowListCommas = DEFAULT_ALWAYS_SHOW_LIST_COMMAS;
-        @ConfigEntry.Gui.Tooltip
         private boolean advancedTooltipsShowsIotaNBT = DEFAULT_ADVANCED_TOOLTIPS_SHOWS_IOTA_NBT;
         @ConfigEntry.Gui.Tooltip
         private boolean staticActiveSlates = DEFAULT_STATIC_ACTIVE_SLATES;
@@ -177,11 +175,6 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         @Override
         public boolean clickingTogglesDrawing() {
              return clickingTogglesDrawing;
-        }
-
-        @Override
-        public boolean alwaysShowListCommas() {
-             return alwaysShowListCommas;
         }
 
         @Override

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
@@ -84,7 +84,6 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
         private static ForgeConfigSpec.BooleanValue invertAbacusScrollDirection;
         private static ForgeConfigSpec.DoubleValue gridSnapThreshold;
         private static ForgeConfigSpec.BooleanValue clickingTogglesDrawing;
-        private static ForgeConfigSpec.BooleanValue alwaysShowListCommas;
         private static ForgeConfigSpec.BooleanValue advancedTooltipsShowsIotaNBT;
         private static ForgeConfigSpec.BooleanValue staticActiveSlates;
 
@@ -109,9 +108,6 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
             clickingTogglesDrawing = builder.comment(
                     "Whether you click to start and stop drawing instead of clicking and dragging")
                 .define("clickingTogglesDrawing", DEFAULT_CLICKING_TOGGLES_DRAWING);
-            alwaysShowListCommas = builder.comment(
-                    "Whether all iota types should be comma-separated in lists (by default, pattern iotas don't use commas)")
-                .define("alwaysShowListCommas", DEFAULT_ALWAYS_SHOW_LIST_COMMAS);
             advancedTooltipsShowsIotaNBT = builder.comment(
                     "Whether enabling advanced tooltips (F3+H) should display the full NBT of iotas stored in items " +
                         "like foci and spellbooks")
@@ -149,11 +145,6 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
         @Override
         public boolean clickingTogglesDrawing() {
             return clickingTogglesDrawing.get();
-        }
-
-        @Override
-        public boolean alwaysShowListCommas() {
-            return alwaysShowListCommas.get();
         }
 
         @Override


### PR DESCRIPTION
This reverts commit 6e04f5623ad4d01c61f4b97d17a1b43c1604659d.

see https://github.com/FallingColors/HexMod/issues/1111#issuecomment-4643661300 for rationale; the config is unsound as is and should not exist or be a common config since iota display is both-sided.