### PR TITLE
Revert "Spell-list comma config toggle" (1.21)

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/ListIota.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/ListIota.java
@@ -1,7 +1,6 @@
 package at.petrak.hexcasting.api.casting.iota;
 
 import at.petrak.hexcasting.api.casting.SpellList;
-import at.petrak.hexcasting.api.mod.HexConfig;
 import at.petrak.hexcasting.common.lib.hex.HexIotaTypes;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.ChatFormatting;
@@ -111,8 +110,7 @@ public class ListIota extends Iota {
             if (i < list.size() - 1) {
                 var thisIotaNeedsComma = sub.type.get() != PatternIota.TYPE;
                 var nextIotaNeedsComma = list.getAt(i + 1).type.get() != PatternIota.TYPE;
-                var alwaysShowCommas = HexConfig.client() != null && HexConfig.client().alwaysShowListCommas();
-                if (thisIotaNeedsComma || nextIotaNeedsComma || alwaysShowCommas)
+                if (thisIotaNeedsComma || nextIotaNeedsComma)
                     out.append(", ");
             }
         }

--- a/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/mod/HexConfig.java
@@ -49,14 +49,11 @@ public class HexConfig {
 
         boolean clickingTogglesDrawing();
 
-        boolean alwaysShowListCommas();
-
         boolean DEFAULT_CTRL_TOGGLES_OFF_STROKE_ORDER = false;
         boolean DEFAULT_INVERT_SPELLBOOK_SCROLL = false;
         boolean DEFAULT_INVERT_ABACUS_SCROLL = false;
         double DEFAULT_GRID_SNAP_THRESHOLD = 0.5;
         boolean DEFAULT_CLICKING_TOGGLES_DRAWING = false;
-        boolean DEFAULT_ALWAYS_SHOW_LIST_COMMAS = false;
     }
 
     public interface ServerConfigAccess {

--- a/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
+++ b/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
@@ -351,10 +351,6 @@
           "": "Clicking Toggles Drawing",
           "@Tooltip": "Whether you click to start and stop drawing instead of clicking and dragging to draw",
         },
-        alwaysShowListCommas: {
-          "": "Always Show List Commas",
-          "@Tooltip": "Whether all iota types should be comma-separated when displayed in lists (by default, pattern iotas do not use commas)",
-        },
       },
       
       server: {

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/FabricHexConfig.java
@@ -135,8 +135,6 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         private double gridSnapThreshold = DEFAULT_GRID_SNAP_THRESHOLD;
         @ConfigEntry.Gui.Tooltip
         private boolean clickingTogglesDrawing = DEFAULT_CLICKING_TOGGLES_DRAWING;
-        @ConfigEntry.Gui.Tooltip
-        private boolean alwaysShowListCommas = DEFAULT_ALWAYS_SHOW_LIST_COMMAS;
 
         @Override
         public void validatePostLoad() throws ValidationException {
@@ -166,11 +164,6 @@ public class FabricHexConfig extends PartitioningSerializer.GlobalData {
         @Override
         public boolean clickingTogglesDrawing() {
              return clickingTogglesDrawing;
-        }
-
-        @Override
-        public boolean alwaysShowListCommas() {
-             return alwaysShowListCommas;
         }
     }
 

--- a/Neoforge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
+++ b/Neoforge/src/main/java/at/petrak/hexcasting/forge/ForgeHexConfig.java
@@ -83,7 +83,6 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
         private static ModConfigSpec.BooleanValue invertAbacusScrollDirection;
         private static ModConfigSpec.DoubleValue gridSnapThreshold;
         private static ModConfigSpec.BooleanValue clickingTogglesDrawing;
-        private static ModConfigSpec.BooleanValue alwaysShowListCommas;
 
         public Client(ModConfigSpec.Builder builder) {
             ctrlTogglesOffStrokeOrder = builder.comment(
@@ -103,9 +102,6 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
             clickingTogglesDrawing = builder.comment(
                             "Whether you click to start and stop drawing instead of clicking and dragging")
                     .define("clickingTogglesDrawing", DEFAULT_CLICKING_TOGGLES_DRAWING);
-            alwaysShowListCommas = builder.comment(
-                            "Whether all iota types should be comma-separated in lists (by default, pattern iotas don't use commas)")
-                    .define("alwaysShowListCommas", DEFAULT_ALWAYS_SHOW_LIST_COMMAS);
         }
 
         @Override
@@ -131,11 +127,6 @@ public class ForgeHexConfig implements HexConfig.CommonConfigAccess {
         @Override
         public boolean clickingTogglesDrawing() {
             return clickingTogglesDrawing.get();
-        }
-
-        @Override
-        public boolean alwaysShowListCommas() {
-            return alwaysShowListCommas.get();
         }
     }
 


### PR DESCRIPTION
This reverts commit 6e04f5623ad4d01c61f4b97d17a1b43c1604659d.

#1112 but it's for the 1.21 branch. see other PR for rationale.