### PR TITLE
Fix Assessor's Purification for scrolls in item frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed a potential chunkban when leaving a looping spell circle running for long enough ([#908](https://github.com/FallingColors/HexMod/pull/908)) @Stick404
 - Fixed a potential issue on MacOS when calculating soulglimmer color ([#984](https://github.com/FallingColors/HexMod/pull/984)) @vgskye
 - Fixed Pace Purification returning nonzero velocity on nonmoving items ([#1119](https://github.com/FallingColors/HexMod/pull/1119)) @IridescentVoid
+- Fixed Accessor's Purification returning false for scrolls in item frames ([#1115](https://github.com/FallingColors/HexMod/pull/1115)) @IridescentVoid
 
 ### Internal
 

--- a/Common/src/main/java/at/petrak/hexcasting/api/addldata/ItemDelegatingEntityIotaHolder.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/addldata/ItemDelegatingEntityIotaHolder.java
@@ -85,5 +85,10 @@ public abstract class ItemDelegatingEntityIotaHolder implements ADIotaHolder {
         public boolean writeIota(@Nullable Iota datum, boolean simulate) {
             return false;
         }
+
+        @Override
+        public boolean writeable() {
+            return false;
+        }
     }
 }

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/rw/OpTheCoolerWritable.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/rw/OpTheCoolerWritable.kt
@@ -21,8 +21,7 @@ object OpTheCoolerWritable : ConstMediaAction {
         val datumHolder = IXplatAbstractions.INSTANCE.findDataHolder(target)
             ?: return false.asActionResult
 
-        val success = datumHolder.writeIota(NullIota(), true)
-
+        val success = datumHolder.writeable()
         return success.asActionResult
     }
 }


### PR DESCRIPTION
Fixes #505

The behavior of Assessor's Purification:
- Item frame with focus - True (correct. before and after PR)
- Wall scroll entity - False (correct. before and after PR, though for different reasons)
- Item frame with scroll - False (incorrect. before) and True (correct. after PR)