### PR TITLE
Hide arrow on argument-less pattern pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Re-implemented the ability to extract stored media from items in trinket/curio slots ([#996](https://github.com/FallingColors/HexMod/pull/996)) @YukkuriC
 - Patterns involving entity look direction now compensate for the vanilla bug that causes projectiles and phantoms to report the wrong direction ([#1025](https://github.com/FallingColors/HexMod/pull/1025)) @Robotgiggle
 - Drawing Evanition with nothing left to do will now undo the opening Introspection ([#1047](https://github.com/FallingColors/HexMod/pull/1047)) @Robotgiggle
+- Book pages for patterns without input/output iotas no longer display the type signature line at all ([#1118](https://github.com/FallingColors/HexMod/pull/1118)) @IridescentVoid
 - Updated Inline dependency from 1.0.1 to 1.2.2 ([#1043](https://github.com/FallingColors/HexMod/pull/1043)) @Robotgiggle
 - Updated Fabric Language Kotlin dependency from 1.9.4 to 1.13.7 ([#1043](https://github.com/FallingColors/HexMod/pull/1043)) @Robotgiggle
 - Updated Kotlin for Forge dependency from 4.3.0 to 4.12.0 ([#1043](https://github.com/FallingColors/HexMod/pull/1043)) @Robotgiggle

--- a/Common/src/main/java/at/petrak/hexcasting/interop/patchouli/PatternProcessor.java
+++ b/Common/src/main/java/at/petrak/hexcasting/interop/patchouli/PatternProcessor.java
@@ -8,18 +8,24 @@ import vazkii.patchouli.api.IVariableProvider;
 
 public class PatternProcessor implements IComponentProcessor {
     private String translationKey;
+    private boolean hasArgs = false;
 
     @Override
     public void setup(Level level, IVariableProvider vars) {
-        if (vars.has("header"))
+        if (vars.has("header")) {
             translationKey = vars.get("header").asString();
-        else {
+        } else {
             IVariable key = vars.get("op_id");
             String opName = key.asString();
 
             String prefix = "hexcasting.action.";
             boolean hasOverride = I18n.exists(prefix + "book." + opName);
             translationKey = prefix + (hasOverride ? "book." : "") + opName;
+
+            if (vars.has("input") && !vars.get("input").asString().isEmpty())
+                hasArgs = true;
+            else if (vars.has("output") && !vars.get("output").asString().isEmpty())
+                hasArgs = true;
         }
     }
 
@@ -27,6 +33,8 @@ public class PatternProcessor implements IComponentProcessor {
     public IVariable process(Level level, String key) {
         if (key.equals("translation_key")) {
             return IVariable.wrap(translationKey);
+        } else if (key.equals("has_signature")) {
+            return IVariable.wrap(hasArgs);
         }
 
         return null;

--- a/Common/src/main/resources/assets/hexcasting/patchouli_books/thehexbook/en_us/templates/manual_pattern.json
+++ b/Common/src/main/resources/assets/hexcasting/patchouli_books/thehexbook/en_us/templates/manual_pattern.json
@@ -23,11 +23,19 @@
     {
       "type": "patchouli:text",
       "text": "$(n)#input#/$ \u2192 $(n)#output#/$",
+      "guard": "#has_signature#",
       "y": 80
     },
     {
       "type": "patchouli:text",
       "text": "#text#",
+      "guard": "#has_signature->inv#",
+      "y": 80
+    },
+    {
+      "type": "patchouli:text",
+      "text": "#text#",
+      "guard": "#has_signature#",
       "y": 89
     }
   ]

--- a/Common/src/main/resources/assets/hexcasting/patchouli_books/thehexbook/en_us/templates/pattern.json
+++ b/Common/src/main/resources/assets/hexcasting/patchouli_books/thehexbook/en_us/templates/pattern.json
@@ -23,11 +23,19 @@
     {
       "type": "patchouli:text",
       "text": "$(n)#input#/$ \u2192 $(n)#output#/$",
+      "guard": "#has_signature#",
       "y": 80
     },
     {
       "type": "patchouli:text",
       "text": "#text#",
+      "guard": "#has_signature->inv#",
+      "y": 80
+    },
+    {
+      "type": "patchouli:text",
+      "text": "#text#",
+      "guard": "#has_signature#",
       "y": 89
     }
   ]


### PR DESCRIPTION
Resolves #566

I don't quite like duplicating the `#text#` component with inverse guard clauses, but the alternative would be putting the y height in the PatternProcessor which feels worse.