### PR TITLE
Add special velocity getter for item entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed a broken translation key when trying to use Place Block with no placeable items in your hotbar ([#1010](https://github.com/FallingColors/HexMod/pull/1010)) @Robotgiggle
 - Fixed a potential chunkban when leaving a looping spell circle running for long enough ([#908](https://github.com/FallingColors/HexMod/pull/908)) @Stick404
 - Fixed a potential issue on MacOS when calculating soulglimmer color ([#984](https://github.com/FallingColors/HexMod/pull/984)) @vgskye
+- Fixed Pace Purification returning nonzero velocity on nonmoving items ([#1119](https://github.com/FallingColors/HexMod/pull/1119)) @IridescentVoid
 
 ### Internal
 

--- a/Common/src/main/java/at/petrak/hexcasting/common/misc/RegisterMisc.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/misc/RegisterMisc.java
@@ -24,6 +24,12 @@ public class RegisterMisc {
         HexAPI.instance().registerSpecialVelocityGetter(EntityType.SPECTRAL_ARROW, RegisterMisc::arrowVelocitizer);
         // this is an arrow apparently
         HexAPI.instance().registerSpecialVelocityGetter(EntityType.TRIDENT, RegisterMisc::arrowVelocitizer);
+        HexAPI.instance().registerSpecialVelocityGetter(EntityType.ITEM, item -> {
+            // Items only tick movement every four ticks if stationary and on ground, but gravity is added every tick
+            // and only cleared by movement logic every four ticks
+            if (item.onGround() && item.getDeltaMovement().horizontalDistanceSqr() <= 1.0E-5F) return Vec3.ZERO;
+            return item.getDeltaMovement();
+        });
 
         HexAPI.instance().registerCustomBrainsweepingBehavior(EntityType.VILLAGER, villager -> {
             ((AccessorVillager) villager).hex$releaseAllPois();


### PR DESCRIPTION
When on the ground and not moving horizontally, item entities only tick their movement every four ticks. However, velocity from gravity is still added every tick. Prior to this PR, that velocity would be reported by Pace Purification.

Fixes #363