### PR TITLE
Fix Hexpattern Codec

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/math/HexPattern.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/math/HexPattern.kt
@@ -125,8 +125,8 @@ data class HexPattern(val startDir: HexDir, val angles: MutableList<HexAngle> = 
         @JvmField
         val CODEC: Codec<HexPattern> = RecordCodecBuilder.create { instance ->
             instance.group(
-                Codec.STRING.fieldOf(TAG_START_DIR).forGetter(HexPattern::anglesSignature),
-                HexDir.CODEC.fieldOf(TAG_ANGLES).forGetter(HexPattern::startDir)
+                Codec.STRING.fieldOf(TAG_ANGLES).forGetter(HexPattern::anglesSignature),
+                HexDir.CODEC.fieldOf(TAG_START_DIR).forGetter(HexPattern::startDir)
             ).apply(instance, HexPattern::fromAnglesUnchecked)
         }
 


### PR DESCRIPTION
Fixes the angle sig being put in the start dir field and the start dir being put in the angle sig field of the HexPattern codec.