### PR TITLE
Fix HexPattern codec with graceful error handling

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/math/HexPattern.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/math/HexPattern.kt
@@ -3,6 +3,7 @@ package at.petrak.hexcasting.api.casting.math
 import at.petrak.hexcasting.api.utils.coordToPx
 import at.petrak.hexcasting.api.utils.findCenter
 import com.mojang.serialization.Codec
+import com.mojang.serialization.DataResult
 import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.network.RegistryFriendlyByteBuf
 import net.minecraft.network.codec.ByteBufCodecs
@@ -118,6 +119,8 @@ data class HexPattern(val startDir: HexDir, val angles: MutableList<HexAngle> = 
         append("]")
     }
 
+    data class RawHexPattern(val startDir: String, val anglesSignature: String)
+
     companion object {
         const val TAG_START_DIR = "start_dir"
         const val TAG_ANGLES = "angles"
@@ -125,10 +128,17 @@ data class HexPattern(val startDir: HexDir, val angles: MutableList<HexAngle> = 
         @JvmField
         val CODEC: Codec<HexPattern> = RecordCodecBuilder.create { instance ->
             instance.group(
-                Codec.STRING.fieldOf(TAG_ANGLES).forGetter(HexPattern::anglesSignature),
-                HexDir.CODEC.fieldOf(TAG_START_DIR).forGetter(HexPattern::startDir)
-            ).apply(instance, HexPattern::fromAnglesUnchecked)
-        }
+                Codec.STRING.fieldOf(TAG_ANGLES).forGetter(RawHexPattern::anglesSignature),
+                Codec.STRING.fieldOf(TAG_START_DIR).forGetter(RawHexPattern::startDir)
+            ).apply(instance, ::RawHexPattern)
+        }.flatXmap({
+            val dir = HexDir.fromString(it.startDir)
+            try {
+                return@flatXmap DataResult.success(fromAnglesUnchecked(it.anglesSignature, dir))
+            } catch (exception: IllegalArgumentException) {
+                return@flatXmap DataResult.error { exception.message }
+            }
+        }, { DataResult.success(RawHexPattern(it.startDir.name, it.anglesSignature())) })
 
         @JvmField
         val STREAM_CODEC: StreamCodec<RegistryFriendlyByteBuf, HexPattern> = StreamCodec.composite(


### PR DESCRIPTION
Fixes #1128 

Root issue was the changes in #1120. This PR prevents upgrading from 1.21 pre-1120 to 1.21 post-1120 from bricking worlds, but pattern iota won't transfer across successfully.

I was expecting to need more changes, but it seems that great scrolls regenerate their data automatically (probably as a result of lazy creative scroll loading) and iota lists convert to garbage.
