### PR TITLE
API: change ActionUtils evaluatable to List<Iota>.getEvaluatable

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/ActionUtils.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/ActionUtils.kt
@@ -290,15 +290,17 @@ fun List<Iota>.getLongOrList(idx: Int, argc: Int = 0): Either<Long, TreeList<Iot
     )
 }
 
-fun evaluatable(datum: Iota, reverseIdx: Int): Either<Iota, TreeList<Iota>> =
-    when (datum) {
+fun List<Iota>.getEvaluatable(idx: Int, argc: Int = 0): Either<Iota, TreeList<Iota>> {
+    val datum = this.getOrElse(idx) { throw MishapNotEnoughArgs(idx + 1, this.size) }
+    return when (datum) {
         is ListIota -> Either.right(datum.list)
-        else -> if (datum.executable()) Either.left(datum) else throw MishapInvalidIota(
+        else -> if (datum.executable()) Either.left(datum) else throw MishapInvalidIota.of(
             datum,
-            reverseIdx,
-            "hexcasting.mishap.invalid_value.evaluatable".asTranslatedComponent
+            if (argc == 0) idx else argc - (idx + 1),
+            "evaluatable"
         )
     }
+}
 
 fun Iota?.orNull() = this ?: NullIota()
 

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/eval/OpEval.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/eval/OpEval.kt
@@ -7,22 +7,27 @@ import at.petrak.hexcasting.api.casting.eval.vm.CastingImage
 import at.petrak.hexcasting.api.casting.eval.vm.FrameEvaluate
 import at.petrak.hexcasting.api.casting.eval.vm.FrameFinishEval
 import at.petrak.hexcasting.api.casting.eval.vm.SpellContinuation
-import at.petrak.hexcasting.api.casting.evaluatable
+import at.petrak.hexcasting.api.casting.getEvaluatable
 import at.petrak.hexcasting.api.casting.iota.Iota
 import at.petrak.hexcasting.api.casting.mishaps.MishapNotEnoughArgs
 import at.petrak.hexcasting.api.utils.TreeList
 import at.petrak.hexcasting.common.lib.hex.HexEvalSounds
+import com.mojang.datafixers.util.Either
 
 object OpEval : Action {
     override fun operate(env: CastingEnvironment, image: CastingImage, continuation: SpellContinuation): OperationResult {
         val stack = image.stack
-        val iota = stack.lastOrNull() ?: throw MishapNotEnoughArgs(1, 0)
-        return exec(env, image, continuation, stack.init(), iota)
+
+        if (stack.size < 1)
+            throw MishapNotEnoughArgs(1, 0)
+
+        val instrs = stack.getEvaluatable(stack.lastIndex, stack.size)
+
+        return exec(env, image, continuation, stack.init(), instrs)
     }
 
-    fun exec(env: CastingEnvironment, image: CastingImage, continuation: SpellContinuation, newStack: TreeList<Iota>, iota: Iota): OperationResult {
+    fun exec(env: CastingEnvironment, image: CastingImage, continuation: SpellContinuation, newStack: TreeList<Iota>, instrs: Either<Iota, TreeList<Iota>>): OperationResult {
         // also, never make a break boundary when evaluating just one pattern
-        val instrs = evaluatable(iota, 0)
         val newCont =
                 if (instrs.left().isPresent || (continuation is SpellContinuation.NotDone && continuation.frame is FrameFinishEval)) {
                     continuation

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/eval/OpEval.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/eval/OpEval.kt
@@ -18,7 +18,7 @@ object OpEval : Action {
     override fun operate(env: CastingEnvironment, image: CastingImage, continuation: SpellContinuation): OperationResult {
         val stack = image.stack
 
-        if (stack.size < 1)
+        if (stack.isEmpty())
             throw MishapNotEnoughArgs(1, 0)
 
         val instrs = stack.getEvaluatable(stack.lastIndex, stack.size)

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/eval/OpEvalBreakable.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/eval/OpEvalBreakable.kt
@@ -5,6 +5,7 @@ import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
 import at.petrak.hexcasting.api.casting.eval.OperationResult
 import at.petrak.hexcasting.api.casting.eval.vm.CastingImage
 import at.petrak.hexcasting.api.casting.eval.vm.SpellContinuation
+import at.petrak.hexcasting.api.casting.getEvaluatable
 import at.petrak.hexcasting.api.casting.iota.ContinuationIota
 import at.petrak.hexcasting.api.casting.mishaps.MishapNotEnoughArgs
 
@@ -13,7 +14,13 @@ object OpEvalBreakable : Action {
                          image: CastingImage,
                          continuation: SpellContinuation): OperationResult {
         val stack = image.stack
-        val iota = stack.lastOrNull() ?: throw MishapNotEnoughArgs(1, 0)
-        return OpEval.exec(env, image, continuation, stack.init().appended(ContinuationIota(continuation)), iota)
+
+        if (stack.size < 1)
+            throw MishapNotEnoughArgs(1, 0)
+
+        val instrs = stack.getEvaluatable(stack.lastIndex, stack.size)
+
+        val newStack = stack.init().appended(ContinuationIota(continuation))
+        return OpEval.exec(env, image, continuation, newStack, instrs)
     }
 }

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/eval/OpEvalBreakable.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/eval/OpEvalBreakable.kt
@@ -15,7 +15,7 @@ object OpEvalBreakable : Action {
                          continuation: SpellContinuation): OperationResult {
         val stack = image.stack
 
-        if (stack.size < 1)
+        if (stack.isEmpty())
             throw MishapNotEnoughArgs(1, 0)
 
         val instrs = stack.getEvaluatable(stack.lastIndex, stack.size)

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/eval/SpecialHandlerForEach.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/eval/SpecialHandlerForEach.kt
@@ -8,7 +8,7 @@ import at.petrak.hexcasting.api.casting.eval.OperationResult
 import at.petrak.hexcasting.api.casting.eval.vm.CastingImage
 import at.petrak.hexcasting.api.casting.eval.vm.FrameForEach
 import at.petrak.hexcasting.api.casting.eval.vm.SpellContinuation
-import at.petrak.hexcasting.api.casting.evaluatable
+import at.petrak.hexcasting.api.casting.getEvaluatable
 import at.petrak.hexcasting.api.casting.getList
 import at.petrak.hexcasting.api.casting.math.HexPattern
 import at.petrak.hexcasting.api.casting.mishaps.MishapNotEnoughArgs
@@ -39,7 +39,7 @@ class SpecialHandlerForEach(val n: Int) : SpecialHandler {
                 throw MishapNotEnoughArgs(2 + n, stack.size)
 
             val datums = stack.getList(stack.lastIndex - 1, stack.size)
-            val instrs = evaluatable(stack[stack.lastIndex], 0)
+            val instrs = stack.getEvaluatable(stack.lastIndex, stack.size)
             stack = stack.dropRight(2)
 
             val instrList = instrs.map({ TreeList.from(listOf(it)) }, { it })


### PR DESCRIPTION
Closes #1124

Depends on #1106. May break addons, but we have no ABI guarantees for 1.21 currently.