### PR TITLE
Fix Iota validation during CastingVM queueExecuteAndWrapIotas

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
@@ -83,7 +83,7 @@ class CastingVM(var image: CastingImage, val env: CastingEnvironment) {
 
             // Then write all pertinent data back to the VM for the next iteration.
             if (image2.newData != null) {
-                this.image = image2.newData
+                this.image = image2.newData.copy(stack = validateIotaList(image2.newData.stack));
             }
             this.env.postExecution(image2)
 

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
@@ -83,7 +83,7 @@ class CastingVM(var image: CastingImage, val env: CastingEnvironment) {
 
             // Then write all pertinent data back to the VM for the next iteration.
             if (image2.newData != null) {
-                this.image = image2.newData.copy(stack = validateIotaList(image2.newData.stack));
+                this.image = image2.newData.copy(stack = validateIotaList(image2.newData.stack, world));
             }
             this.env.postExecution(image2)
 


### PR DESCRIPTION
Fixes iota validation in `CastingVM`'s `queueExecuteAndWrapIotas`. When you cast a hex that reads an invalid iota (for example, an entity iota in a focus, unloaded), and then use it in some pattern, it crashes with a `NullPointerException`. This fixes that issue by validating the stack inbetween every continuation advance.