### PR TITLE
fix mods.toml to list Curios dependency as Accessories is only used on Fabric

### DIFF
--- a/Neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/Neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -62,6 +62,6 @@ ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.hexcasting]]
-modId = "accessories"
+modId = "curios"
 mandatory = false
-versionRange = "[1.1.0-beta.16+1.21.1,)"
+versionRange = "[9.5.1+1.21.1,)"


### PR DESCRIPTION
Ideally in the future the Xplat needed is removed but ATM10 at the very least has an explicit check + crash for if the Accessories Compatibility Layer is detected. So I think for now rather than moving 1.21 to Accessories on Forge the better solution is to just continue Xplatting it