### PR TITLE
Use music discs c-tag rather than vanilla creeper-drops tag

### DIFF
--- a/Common/src/generated/resources/data/hexcasting/recipe/artifact.json
+++ b/Common/src/generated/resources/data/hexcasting/recipe/artifact.json
@@ -6,7 +6,7 @@
       "item": "hexcasting:charged_amethyst"
     },
     "D": {
-      "tag": "minecraft:creeper_drop_music_discs"
+      "tag": "c:music_discs"
     },
     "F": {
       "tag": "c:ingots/gold"

--- a/Common/src/main/java/at/petrak/hexcasting/datagen/recipe/HexplatRecipes.java
+++ b/Common/src/main/java/at/petrak/hexcasting/datagen/recipe/HexplatRecipes.java
@@ -27,6 +27,7 @@ import net.minecraft.advancements.critereon.InventoryChangeTrigger;
 import net.minecraft.advancements.critereon.ItemPredicate;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.recipes.*;
 import net.minecraft.resources.ResourceLocation;
@@ -155,9 +156,8 @@ public class HexplatRecipes extends RecipeProvider {
         ShapedRecipeBuilder.shaped(RecipeCategory.TOOLS, HexItems.ARTIFACT)
             .define('F', ingredients.goldIngot())
             .define('A', HexItems.CHARGED_AMETHYST)
-            // why in god's name does minecraft have two different places for item tags
-            // TODO port: check if good for music discs
-            .define('D', ItemTags.CREEPER_DROP_MUSIC_DISCS)
+            // 1.21 removed the vanilla music discs tag so we need to use this instead
+            .define('D', TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("c","music_discs")))
             .pattern(" F ")
             .pattern("FAF")
             .pattern(" D ")

--- a/Fabric/src/generated/resources/data/hexcasting/recipe/artifact.json
+++ b/Fabric/src/generated/resources/data/hexcasting/recipe/artifact.json
@@ -6,7 +6,7 @@
       "item": "hexcasting:charged_amethyst"
     },
     "D": {
-      "tag": "minecraft:creeper_drop_music_discs"
+      "tag": "c:music_discs"
     },
     "F": [
       {

--- a/Neoforge/src/generated/resources/data/hexcasting/recipe/artifact.json
+++ b/Neoforge/src/generated/resources/data/hexcasting/recipe/artifact.json
@@ -6,7 +6,7 @@
       "item": "hexcasting:charged_amethyst"
     },
     "D": {
-      "tag": "minecraft:creeper_drop_music_discs"
+      "tag": "c:music_discs"
     },
     "F": {
       "tag": "c:ingots/gold"


### PR DESCRIPTION
Minecraft 1.21 removed the `minecraft:music_discs` tag that had been used for the artifact crafting recipe, and our 1.21 port initially dealt with that by using `minecraft:creeper_drop_music_discs` in the recipe instead. However, that excludes 7 out of the 19 vanilla discs, along with any discs added by other mods. This PR changes the artifact recipe to use `c:music_discs` instead, solving both of those issues.

Bonus note: the Supplementaries pancake is **not** in `c:music_discs`, so this change does not reintroduce the artifact recipe cheese that was possible in 1.20.