### PR TITLE
Fix stale entity iotas read from holders

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/ActionUtils.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/ActionUtils.kt
@@ -4,6 +4,7 @@ package at.petrak.hexcasting.api.casting
 
 import at.petrak.hexcasting.api.casting.iota.*
 import at.petrak.hexcasting.api.casting.math.HexPattern
+import at.petrak.hexcasting.api.casting.mishaps.MishapEntityNotFound
 import at.petrak.hexcasting.api.casting.mishaps.MishapInvalidIota
 import at.petrak.hexcasting.api.casting.mishaps.MishapNotEnoughArgs
 import at.petrak.hexcasting.api.utils.asTranslatedComponent
@@ -37,7 +38,7 @@ fun List<Iota>.getDouble(idx: Int, argc: Int = 0): Double {
 fun List<Iota>.getEntity(level: ServerLevel, idx: Int, argc: Int = 0): Entity {
     val x = this.getOrElse(idx) { throw MishapNotEnoughArgs(idx + 1, this.size) }
     if (x is EntityIota) {
-        return x.getEntity(level)
+        return x.getEntity(level) ?: throw MishapEntityNotFound(x.entityId, x.entityName)
     } else {
         throw MishapInvalidIota.ofType(x, if (argc == 0) idx else argc - (idx + 1), "entity")
     }
@@ -84,7 +85,7 @@ fun List<Iota>.getBool(idx: Int, argc: Int = 0): Boolean {
 fun List<Iota>.getItemEntity(level: ServerLevel, idx: Int, argc: Int = 0): ItemEntity {
     val x = this.getOrElse(idx) { throw MishapNotEnoughArgs(idx + 1, this.size) }
     if (x is EntityIota) {
-        val e = x.getEntity(level)
+        val e = x.getEntity(level) ?: throw MishapEntityNotFound(x.entityId, x.entityName)
         if (e is ItemEntity)
             return e
     }
@@ -94,7 +95,7 @@ fun List<Iota>.getItemEntity(level: ServerLevel, idx: Int, argc: Int = 0): ItemE
 fun List<Iota>.getPlayer(level: ServerLevel, idx: Int, argc: Int = 0): ServerPlayer {
     val x = this.getOrElse(idx) { throw MishapNotEnoughArgs(idx + 1, this.size) }
     if (x is EntityIota) {
-        val e = x.getEntity(level)
+        val e = x.getEntity(level) ?: throw MishapEntityNotFound(x.entityId, x.entityName)
         if (e is ServerPlayer)
             return e
     }
@@ -104,7 +105,7 @@ fun List<Iota>.getPlayer(level: ServerLevel, idx: Int, argc: Int = 0): ServerPla
 fun List<Iota>.getMob(level: ServerLevel, idx: Int, argc: Int = 0): Mob {
     val x = this.getOrElse(idx) { throw MishapNotEnoughArgs(idx + 1, this.size) }
     if (x is EntityIota) {
-        val e = x.getEntity(level)
+        val e = x.getEntity(level) ?: throw MishapEntityNotFound(x.entityId, x.entityName)
         if (e is Mob)
             return e
     }
@@ -114,7 +115,7 @@ fun List<Iota>.getMob(level: ServerLevel, idx: Int, argc: Int = 0): Mob {
 fun List<Iota>.getLivingEntityButNotArmorStand(level: ServerLevel, idx: Int, argc: Int = 0): LivingEntity {
     val x = this.getOrElse(idx) { throw MishapNotEnoughArgs(idx + 1, this.size) }
     if (x is EntityIota) {
-        val e = x.getEntity(level)
+        val e = x.getEntity(level) ?: throw MishapEntityNotFound(x.entityId, x.entityName)
         if (e is LivingEntity && e !is ArmorStand)
             return e
     }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/EntityIota.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/iota/EntityIota.java
@@ -21,7 +21,6 @@ import net.minecraft.world.item.component.ResolvableProfile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.ref.WeakReference;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -44,7 +43,7 @@ public class EntityIota extends Iota {
         return entityId;
     }
 
-    public Entity getEntity(ServerLevel level) {
+    public @Nullable Entity getEntity(ServerLevel level) {
         return level.getEntity(entityId);
     }
 

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInternalException.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInternalException.kt
@@ -14,5 +14,5 @@ class MishapInternalException(val exception: Exception) : Mishap() {
     }
 
     override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
-        error("unknown", exception)
+        error("unknown", exception.toString())
 }

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/rw/OpRead.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/rw/OpRead.kt
@@ -4,6 +4,7 @@ import at.petrak.hexcasting.api.casting.castables.ConstMediaAction
 import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
 import at.petrak.hexcasting.api.casting.iota.Iota
 import at.petrak.hexcasting.api.casting.mishaps.MishapBadOffhandItem
+import at.petrak.hexcasting.api.utils.validateIota
 import at.petrak.hexcasting.xplat.IXplatAbstractions
 
 object OpRead : ConstMediaAction {
@@ -28,6 +29,6 @@ object OpRead : ConstMediaAction {
             ?: datumHolder.emptyIota()
             ?: throw MishapBadOffhandItem.of(handStack, "iota.read")
 
-        return listOf(datum)
+        return listOf(validateIota(datum, env.world))
     }
 }

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/rw/OpTheCoolerRead.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/rw/OpTheCoolerRead.kt
@@ -5,6 +5,7 @@ import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
 import at.petrak.hexcasting.api.casting.getEntity
 import at.petrak.hexcasting.api.casting.iota.Iota
 import at.petrak.hexcasting.api.casting.mishaps.MishapBadEntity
+import at.petrak.hexcasting.api.utils.validateIota
 import at.petrak.hexcasting.xplat.IXplatAbstractions
 
 object OpTheCoolerRead : ConstMediaAction {
@@ -24,6 +25,6 @@ object OpTheCoolerRead : ConstMediaAction {
         val datum = datumHolder.readIota()
             ?: datumHolder.emptyIota()
             ?: throw MishapBadEntity.of(target, "iota.read")
-        return listOf(datum)
+        return listOf(validateIota(datum, env.world))
     }
 }


### PR DESCRIPTION
Fixes stale `EntityIota` values read from iota holders. Fixes #1160

When an `EntityIota` stored in a readable holder points to an entity that no longer exists, `OpRead` and `OpTheCoolerRead` returned the stale iota directly. The VM only validates the existing stack at the start of execution, so a newly-read stale entity iota could remain usable until the next validation pass.

This could cause entity-consuming patterns to receive an invalid `EntityIota`, leading to an internal `getEntity(...) must not be null` exception. In some environments, the resulting unknown mishap message could also fail to encode as a `system_chat` packet because the raw exception object was passed as a translatable component argument.

Changes:
- Validate iotas read from holders before returning them.
- Treat missing entities from `EntityIota` as `MishapEntityNotFound` instead of allowing a null entity to trigger an internal exception.
- Mark `EntityIota#getEntity` as nullable.
- Convert internal mishap exceptions to strings before using them in translated chat messages.

Tested with:

```text
./gradlew :Neoforge:build
./gradlew :Fabric:build
```
- Runtime-tested on NeoForge.
- Fabric was build-tested only.