### PR TITLE
fix: readd deserialization-time validation for iota holders

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/addldata/ADIotaHolder.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/addldata/ADIotaHolder.java
@@ -1,12 +1,13 @@
 package at.petrak.hexcasting.api.addldata;
 
 import at.petrak.hexcasting.api.casting.iota.Iota;
+import net.minecraft.server.level.ServerLevel;
 import org.jetbrains.annotations.Nullable;
 
 public interface ADIotaHolder {
 
     @Nullable
-    Iota readIota();
+    Iota readIota(ServerLevel world);
 
     @Nullable
     default Iota emptyIota() {

--- a/Common/src/main/java/at/petrak/hexcasting/api/addldata/ItemDelegatingEntityIotaHolder.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/addldata/ItemDelegatingEntityIotaHolder.java
@@ -3,6 +3,7 @@ package at.petrak.hexcasting.api.addldata;
 import at.petrak.hexcasting.api.casting.iota.Iota;
 import at.petrak.hexcasting.common.entities.EntityWallScroll;
 import at.petrak.hexcasting.xplat.IXplatAbstractions;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.decoration.ItemFrame;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
@@ -39,9 +40,9 @@ public abstract class ItemDelegatingEntityIotaHolder implements ADIotaHolder {
     }
 
     @Override
-    public @Nullable Iota readIota() {
+    public @Nullable Iota readIota(ServerLevel world) {
         var delegate = IXplatAbstractions.INSTANCE.findDataHolder(this.stackSupplier.get());
-        return delegate == null ? null : delegate.readIota();
+        return delegate == null ? null : delegate.readIota(world);
     }
 
     @Override

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
@@ -77,7 +77,11 @@ class CastingVM(var image: CastingImage, val env: CastingEnvironment) {
                         sound = HexEvalSounds.MISHAP,
                     )
                 } else {
-                    result
+                    result.copy(
+                        newData = result.newData?.copy(
+                            stack = validateIotaList(result.newData.stack, world)
+                        )
+                    )
                 }
             }
 

--- a/Common/src/main/java/at/petrak/hexcasting/api/utils/HexUtils.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/utils/HexUtils.kt
@@ -317,6 +317,10 @@ fun <T : Iota> validateIota(iota: T, serverLevel: ServerLevel): Iota {
     }
 }
 
+fun <T: Iota> validateIotaNullable(iota: T?, serverLevel: ServerLevel): Iota? {
+    return iota?.let { validateIota(iota, serverLevel) }
+}
+
 fun <T : Iota> validateIotaList(iotaList: List<T>, serverLevel: ServerLevel): List<Iota> {
     return iotaList.map { validateIota(it, serverLevel) }
 }

--- a/Common/src/main/java/at/petrak/hexcasting/common/blocks/circles/impetuses/BlockRedstoneImpetus.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/blocks/circles/impetuses/BlockRedstoneImpetus.java
@@ -68,7 +68,7 @@ public class BlockRedstoneImpetus extends BlockAbstractImpetus {
             } else {
                 var datumContainer = IXplatAbstractions.INSTANCE.findDataHolder(usedStack);
                 if (datumContainer != null) {
-                    var stored = datumContainer.readIota();
+                    var stored = datumContainer.readIota(sLevel);
                     if (stored instanceof EntityIota eieio) {
                         var entity = eieio.getEntity(sLevel);
                         if (entity instanceof Player iotaPlayer) {

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/rw/OpRead.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/rw/OpRead.kt
@@ -12,7 +12,7 @@ object OpRead : ConstMediaAction {
     override fun execute(args: List<Iota>, env: CastingEnvironment): List<Iota> {
         val (handStack) = env.getHeldItemToOperateOn {
             val dataHolder = IXplatAbstractions.INSTANCE.findDataHolder(it)
-            dataHolder != null && (dataHolder.readIota() != null || dataHolder.emptyIota() != null)
+            dataHolder != null && (dataHolder.readIota(env.world) != null || dataHolder.emptyIota() != null)
         }
             // If there are no data holders that are readable, find a data holder that isn't readable
             // so that the error message is more helpful.
@@ -24,7 +24,7 @@ object OpRead : ConstMediaAction {
         val datumHolder = IXplatAbstractions.INSTANCE.findDataHolder(handStack)
             ?: throw MishapBadOffhandItem.of(handStack, "iota.read")
 
-        val datum = datumHolder.readIota()
+        val datum = datumHolder.readIota(env.world)
             ?: datumHolder.emptyIota()
             ?: throw MishapBadOffhandItem.of(handStack, "iota.read")
 

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/rw/OpReadable.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/rw/OpReadable.kt
@@ -18,7 +18,7 @@ object OpReadable : ConstMediaAction {
             ?: return false.asActionResult
 
         // If the datum contains no iota, return whether it has a default empty iota.
-        datumHolder.readIota()
+        datumHolder.readIota(env.world)
             ?: return (datumHolder.emptyIota() != null).asActionResult
 
         return true.asActionResult

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/rw/OpTheCoolerRead.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/rw/OpTheCoolerRead.kt
@@ -21,7 +21,7 @@ object OpTheCoolerRead : ConstMediaAction {
         val datumHolder = IXplatAbstractions.INSTANCE.findDataHolder(target)
             ?: throw MishapBadEntity.of(target, "iota.read")
 
-        val datum = datumHolder.readIota()
+        val datum = datumHolder.readIota(env.world)
             ?: datumHolder.emptyIota()
             ?: throw MishapBadEntity.of(target, "iota.read")
         return listOf(datum)

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/rw/OpTheCoolerReadable.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/rw/OpTheCoolerReadable.kt
@@ -20,7 +20,7 @@ object OpTheCoolerReadable : ConstMediaAction {
         val datumHolder = IXplatAbstractions.INSTANCE.findDataHolder(target)
             ?: return false.asActionResult
 
-        datumHolder.readIota()
+        datumHolder.readIota(env.world)
             ?: datumHolder.emptyIota()
             ?: return false.asActionResult
 

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/cc/adimpl/CCEntityIotaHolder.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/cc/adimpl/CCEntityIotaHolder.java
@@ -4,6 +4,7 @@ import at.petrak.hexcasting.api.addldata.ItemDelegatingEntityIotaHolder;
 import at.petrak.hexcasting.api.casting.iota.Iota;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -27,8 +28,8 @@ public abstract class CCEntityIotaHolder implements CCIotaHolder {
 
 
         @Override
-        public @Nullable Iota readIota() {
-            return inner.readIota();
+        public @Nullable Iota readIota(ServerLevel world) {
+            return inner.readIota(world);
         }
 
         @Override

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/cc/adimpl/CCItemIotaHolder.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/cc/adimpl/CCItemIotaHolder.java
@@ -4,11 +4,14 @@ import at.petrak.hexcasting.api.casting.iota.Iota;
 import at.petrak.hexcasting.api.item.IotaHolderItem;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 import org.ladysnake.cca.api.v3.component.Component;
 
 import java.util.function.Function;
+
+import static at.petrak.hexcasting.api.utils.HexUtils.validateIotaNullable;
 
 public abstract class CCItemIotaHolder implements CCIotaHolder, Component {
     final ItemStack stack;
@@ -28,8 +31,8 @@ public abstract class CCItemIotaHolder implements CCIotaHolder, Component {
         }
 
         @Override
-        public @Nullable Iota readIota() {
-            return this.iotaHolder.readIota(this.stack);
+        public @Nullable Iota readIota(ServerLevel world) {
+            return validateIotaNullable(this.iotaHolder.readIota(this.stack), world);
         }
 
         @Override
@@ -69,7 +72,7 @@ public abstract class CCItemIotaHolder implements CCIotaHolder, Component {
         }
 
         @Override
-        public @Nullable Iota readIota() {
+        public @Nullable Iota readIota(ServerLevel world) {
             return this.provider.apply(this.stack);
         }
 

--- a/Neoforge/src/main/java/at/petrak/hexcasting/forge/cap/adimpl/CapEntityIotaHolder.java
+++ b/Neoforge/src/main/java/at/petrak/hexcasting/forge/cap/adimpl/CapEntityIotaHolder.java
@@ -3,6 +3,7 @@ package at.petrak.hexcasting.forge.cap.adimpl;
 import at.petrak.hexcasting.api.addldata.ADIotaHolder;
 import at.petrak.hexcasting.api.addldata.ItemDelegatingEntityIotaHolder;
 import at.petrak.hexcasting.api.casting.iota.Iota;
+import net.minecraft.server.level.ServerLevel;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class CapEntityIotaHolder implements ADIotaHolder {
@@ -24,8 +25,8 @@ public abstract class CapEntityIotaHolder implements ADIotaHolder {
         }
 
         @Override
-        public @Nullable Iota readIota() {
-            return inner.readIota();
+        public @Nullable Iota readIota(ServerLevel world) {
+            return inner.readIota(world);
         }
 
         @Override

--- a/Neoforge/src/main/java/at/petrak/hexcasting/forge/cap/adimpl/CapItemIotaHolder.java
+++ b/Neoforge/src/main/java/at/petrak/hexcasting/forge/cap/adimpl/CapItemIotaHolder.java
@@ -3,15 +3,18 @@ package at.petrak.hexcasting.forge.cap.adimpl;
 import at.petrak.hexcasting.api.addldata.ADIotaHolder;
 import at.petrak.hexcasting.api.casting.iota.Iota;
 import at.petrak.hexcasting.api.item.IotaHolderItem;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
+
+import static at.petrak.hexcasting.api.utils.HexUtils.validateIotaNullable;
 
 public record CapItemIotaHolder(IotaHolderItem holder, ItemStack stack) implements ADIotaHolder {
 
     @Override
     public @Nullable
-    Iota readIota() {
-        return holder.readIota(stack);
+    Iota readIota(ServerLevel world) {
+        return validateIotaNullable(holder.readIota(stack), world);
     }
 
     @Override

--- a/Neoforge/src/main/java/at/petrak/hexcasting/forge/cap/adimpl/CapStaticIotaHolder.java
+++ b/Neoforge/src/main/java/at/petrak/hexcasting/forge/cap/adimpl/CapStaticIotaHolder.java
@@ -2,6 +2,7 @@ package at.petrak.hexcasting.forge.cap.adimpl;
 
 import at.petrak.hexcasting.api.addldata.ADIotaHolder;
 import at.petrak.hexcasting.api.casting.iota.Iota;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,7 +13,7 @@ public record CapStaticIotaHolder(Function<ItemStack, Iota> provider,
 
     @Override
     public @Nullable
-    Iota readIota() {
+    Iota readIota(ServerLevel world) {
         return provider.apply(stack);
     }
 

--- a/Neoforge/src/main/java/at/petrak/hexcasting/forge/recipe/ForgeUnsealedIngredient.java
+++ b/Neoforge/src/main/java/at/petrak/hexcasting/forge/recipe/ForgeUnsealedIngredient.java
@@ -2,6 +2,7 @@ package at.petrak.hexcasting.forge.recipe;
 
 import at.petrak.hexcasting.api.addldata.ADIotaHolder;
 import at.petrak.hexcasting.api.casting.iota.NullIota;
+import at.petrak.hexcasting.api.item.IotaHolderItem;
 import at.petrak.hexcasting.common.lib.HexDataComponents;
 import at.petrak.hexcasting.forge.lib.ForgeHexIngredientTypes;
 import at.petrak.hexcasting.xplat.IXplatAbstractions;
@@ -56,8 +57,8 @@ public class ForgeUnsealedIngredient implements ICustomIngredient {
         }
         if (this.stack.getItem() == input.getItem() && this.stack.getDamageValue() == input.getDamageValue()) {
             ADIotaHolder holder = IXplatAbstractions.INSTANCE.findDataHolder(this.stack);
-            if (holder != null) {
-                return holder.readIota() != null && holder.writeIota(new NullIota(), true);
+            if (holder != null && this.stack.getItem() instanceof IotaHolderItem holderItem) {
+                return holderItem.readIota(this.stack) != null && holder.writeIota(new NullIota(), true);
             }
         }
 


### PR DESCRIPTION
Fixes #1160 

Alternative implementation of #1161 that performs iota validation in the `readIota()` call where the iota component is deserialized instead of when OpRead/OpTheCoolerRead return. This should better ensure that the validation code gets called in the future as well.

I also opted to validate the stack to null newly disappeared entity iota after each frame, which should properly prevent anything from consuming invalid iota. This might have performance implications. Interestingly, 0.11.3 on 1.20.1 would have allowed operating on nonexistent/despawned entities as EntityIota used to hold Entity references directly.

Closes #1161