### PR TITLE
Implement Fisherman's Gambit III

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Updated to Minecraft 1.21.1 ([#985](https://github.com/FallingColors/HexMod/pull/985)) @SuperKnux @slava110
+- Added Fisherman's Gambit III ([#1178](https://github.com/FallingColors/HexMod/pull/1178)) @IridescentVoid
 
 ### Fixed
 

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/stack/OpFishermanButItCopiesInPlace.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/stack/OpFishermanButItCopiesInPlace.kt
@@ -1,0 +1,28 @@
+package at.petrak.hexcasting.common.casting.actions.stack
+
+import at.petrak.hexcasting.api.casting.castables.Action
+import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
+import at.petrak.hexcasting.api.casting.eval.OperationResult
+import at.petrak.hexcasting.api.casting.eval.vm.CastingImage
+import at.petrak.hexcasting.api.casting.eval.vm.SpellContinuation
+import at.petrak.hexcasting.api.casting.getIntBetween
+import at.petrak.hexcasting.api.casting.mishaps.MishapNotEnoughArgs
+import at.petrak.hexcasting.common.lib.hex.HexEvalSounds
+
+object OpFishermanButItCopiesInPlace : Action {
+    override fun operate(env: CastingEnvironment, image: CastingImage, continuation: SpellContinuation): OperationResult {
+        val stack = image.stack.toMutableList()
+
+        if (stack.size < 2)
+            throw MishapNotEnoughArgs(2, stack.size)
+
+        val depth = stack.getIntBetween(stack.lastIndex, 0, stack.size - 2)
+        stack.removeLast()
+
+        val fish = stack[stack.size - 1 - depth]
+        stack.add(stack.size - 1 - depth, fish)
+
+        val image2 = image.withUsedOp().copy(stack = stack)
+        return OperationResult(image2, listOf(), continuation, HexEvalSounds.NORMAL_EXECUTE)
+    }
+}

--- a/Common/src/main/java/at/petrak/hexcasting/common/lib/hex/HexActions.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/lib/hex/HexActions.java
@@ -135,6 +135,8 @@ public class HexActions {
         new ActionRegistryEntry(HexPattern.fromAngles("ddad", HexDir.WEST), OpFisherman.INSTANCE));
     public static final ActionRegistryEntry FISHERMAN$COPY = make("fisherman/copy",
         new ActionRegistryEntry(HexPattern.fromAngles("aada", HexDir.EAST), OpFishermanButItCopies.INSTANCE));
+    public static final ActionRegistryEntry FISHERMAN$IN_PLACE = make("fisherman/in_place",
+        new ActionRegistryEntry(HexPattern.fromAngles("dadd", HexDir.NORTH_EAST), OpFishermanButItCopiesInPlace.INSTANCE));
     public static final ActionRegistryEntry SWIZZLE = make("swizzle",
         new ActionRegistryEntry(HexPattern.fromAngles("qaawdde",
             HexDir.SOUTH_EAST), OpAlwinfyHasAscendedToABeingOfPureMath.INSTANCE));

--- a/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
+++ b/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
@@ -797,6 +797,7 @@
         stack_len: "Flock's Reflection",
         fisherman: "Fisherman's Gambit",
         "fisherman/copy": "Fisherman's Gambit II",
+        "fisherman/in_place": "Fisherman's Gambit III",
         swizzle: "Swindler's Gambit",
         
         unique: "Uniqueness Purification",
@@ -1885,7 +1886,8 @@
         duplicate_n: "Removes the number at the top of the stack, then copies the top iota of the stack that number of times. (A count of 2 results in two of the iota on the stack, not three.)",
         fisherman: "Grabs the element in the stack indexed by the number and brings it to the top. If the number is negative, instead moves the top element of the stack down that many elements.",
         "fisherman/copy": "Like $(l:patterns/stackmanip#hexcasting:fisherman)$(action)Fisherman's Gambit/$, but instead of moving the iota, copies it.",
-        
+        "fisherman/in_place": "Like $(l:patterns/stackmanip#hexcasting:fisherman)$(action)Fisherman's Gambit II/$, but duplicates the iota in-place. (For example, a stack of [0, 1, 1] will become [0, 0, 1].)",
+
         mask: {
           "1": "An infinite family of actions that keep or remove elements at the top of the stack based on the sequence of dips and lines.",
           "2": "Assuming that I draw a Bookkeeper's Gambit pattern left-to-right, the number of iotas the action will require is determined by the horizontal distance covered by the pattern. From deepest in the stack to shallowest, a flat line will keep the iota, whereas a triangle dipping down will remove it.$(br2)If my stack contains $(italic)0, 1, 2/$ from deepest to shallowest, drawing the first pattern opposite will give me $(italic)1/$, the second will give me $(italic)0/$, and the third will give me $(italic)0, 2/$ (the 0 at the bottom is left untouched).",

--- a/Common/src/main/resources/assets/hexcasting/patchouli_books/thehexbook/en_us/entries/patterns/stackmanip.json
+++ b/Common/src/main/resources/assets/hexcasting/patchouli_books/thehexbook/en_us/entries/patterns/stackmanip.json
@@ -111,6 +111,14 @@
       "text": "hexcasting.page.stackmanip.fisherman/copy"
     },
     {
+      "type": "hexcasting:pattern",
+      "op_id": "hexcasting:fisherman/in_place",
+      "anchor": "hexcasting:fisherman/in_place",
+      "input": "number",
+      "output": "any",
+      "text": "hexcasting.page.stackmanip.fisherman/in_place"
+    },
+    {
       "type": "hexcasting:manual_pattern",
       "op_id": "hexcasting:mask",
       "anchor": "hexcasting:mask",


### PR DESCRIPTION
Duplicates an iota in-place on the stack.

On a stack of 0, 1, 2, 1, casting Fisherman's Gambit III results in 0, 1, 1, 2.