### PR TITLE
fix non-drawable patterns' stream codec

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/math/HexPattern.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/math/HexPattern.kt
@@ -144,7 +144,7 @@ data class HexPattern(val startDir: HexDir, val angles: MutableList<HexAngle> = 
         val STREAM_CODEC: StreamCodec<RegistryFriendlyByteBuf, HexPattern> = StreamCodec.composite(
             ByteBufCodecs.STRING_UTF8, HexPattern::anglesSignature,
             HexDir.STREAM_CODEC, HexPattern::startDir,
-            HexPattern::fromAngles
+            HexPattern::fromAnglesUnchecked
         )
 
         /**


### PR DESCRIPTION
it used to use `fromAngles`, but it should be using `fromAnglesUnchecked`.