### PR TITLE
Document head, tail, init, last in TreeList

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/utils/TreeList.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/utils/TreeList.java
@@ -464,26 +464,58 @@ public sealed abstract class TreeList<A> extends AbstractList<A> implements Rand
         } else return new TreeListBuilder<A>().initFrom(this).addAll(suffix).result();
     }
 
+    /**
+     * @param n the number of elements to keep
+     * @return a new TreeList containing only the first {@code n} elements of this TreeList
+     */
     public final TreeList<A> take(int n) {
         return this.slice(0, n);
     }
 
+    /**
+     * @param n the number of elements to discard
+     * @return a new TreeList containing all but the first {@code n} elements of this TreeList
+     */
     public final TreeList<A> drop(int n) {
         return this.slice(n, this.length());
     }
 
+    /**
+     * @param n the number of elements to keep
+     * @return a new TreeList containing only the last {@code n} elements of this TreeList
+     */
     public final TreeList<A> takeRight(int n) {
         return this.slice(this.length() - Math.max(n, 0), this.length());
     }
 
+    /**
+     * @param n the number of elements to discard
+     * @return a new TreeList containing all but the last {@code n} elements of this TreeList
+     */
     public final TreeList<A> dropRight(int n) {
         return this.slice(0, this.length() - Math.max(n, 0));
     }
 
+    /**
+     * {@snippet :
+     *     TreeList<String> x = TreeList.from(List.of("a", "b", "c"));
+     *     assert TreeList.from(List.of("b", "c")).equals(x.tail());
+     * }
+     *
+     * @return a new TreeList containing all the elements from this TreeList except for the first one
+     */
     public TreeList<A> tail() {
         return this.slice(1, this.length());
     }
 
+    /**
+     * {@snippet :
+     *     TreeList<String> x = TreeList.from(List.of("a", "b", "c"));
+     *     assert TreeList.from(List.of("a", "b")).equals(x.init());
+     * }
+     *
+     * @return a new TreeList containing all the elements from this TreeList except for the last one
+     */
     public TreeList<A> init() {
         return this.slice(0, this.length() - 1);
     }
@@ -498,11 +530,27 @@ public sealed abstract class TreeList<A> extends AbstractList<A> implements Rand
     /** Length of all slices up to and including index */
     abstract int treeListSlicePrefixLength(int idx);
 
+    /**
+     * {@snippet :
+     *     TreeList<String> x = TreeList.from(List.of("a", "b", "c"));
+     *     assert "a".equals(x.head());
+     * }
+     *
+     * @return the first element of this TreeList
+     */
     public final A head() {
         if(this.prefix1.length == 0) throw new NoSuchElementException("empty.head");
         else return (A) this.prefix1[0];
     }
 
+    /**
+     * {@snippet :
+     *     TreeList<String> x = TreeList.from(List.of("a", "b", "c"));
+     *     assert "c".equals(x.last());
+     * }
+     *
+     * @return the last element of this TreeList
+     */
     public A last() {
         return (A) this.prefix1[this.prefix1.length - 1];
     }

--- a/Common/src/main/java/at/petrak/hexcasting/api/utils/TreeList.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/utils/TreeList.java
@@ -497,11 +497,6 @@ public sealed abstract class TreeList<A> extends AbstractList<A> implements Rand
     }
 
     /**
-     * {@snippet :
-     *     TreeList<String> x = TreeList.from(List.of("a", "b", "c"));
-     *     assert TreeList.from(List.of("b", "c")).equals(x.tail());
-     * }
-     *
      * @return a new TreeList containing all the elements from this TreeList except for the first one
      */
     public TreeList<A> tail() {
@@ -509,11 +504,6 @@ public sealed abstract class TreeList<A> extends AbstractList<A> implements Rand
     }
 
     /**
-     * {@snippet :
-     *     TreeList<String> x = TreeList.from(List.of("a", "b", "c"));
-     *     assert TreeList.from(List.of("a", "b")).equals(x.init());
-     * }
-     *
      * @return a new TreeList containing all the elements from this TreeList except for the last one
      */
     public TreeList<A> init() {
@@ -531,11 +521,6 @@ public sealed abstract class TreeList<A> extends AbstractList<A> implements Rand
     abstract int treeListSlicePrefixLength(int idx);
 
     /**
-     * {@snippet :
-     *     TreeList<String> x = TreeList.from(List.of("a", "b", "c"));
-     *     assert "a".equals(x.head());
-     * }
-     *
      * @return the first element of this TreeList
      */
     public final A head() {
@@ -544,11 +529,6 @@ public sealed abstract class TreeList<A> extends AbstractList<A> implements Rand
     }
 
     /**
-     * {@snippet :
-     *     TreeList<String> x = TreeList.from(List.of("a", "b", "c"));
-     *     assert "c".equals(x.last());
-     * }
-     *
      * @return the last element of this TreeList
      */
     public A last() {


### PR DESCRIPTION
Closes #1200 

This is how it looks in IJ:

<img width="1037" height="335" alt="{D55CE6B8-A345-48EE-AA61-3C0463DE6D05}" src="https://github.com/user-attachments/assets/3063d098-9105-4a50-a9d6-cdea471f1a64" />

Not pretty, but not outright horrible...