### PR TITLE
Use gnomecraft mirror for terraformersmc maven (1.21)

### DIFF
--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -25,7 +25,8 @@ repositories {
 
     maven { url "https://maven.shedaniel.me/" }
     // EMI
-    maven { url = "https://maven.terraformersmc.com/releases/" }
+    // temporarily changed from https://maven.terraformersmc.com/releases/ due to intermittent errors
+    maven { url = "https://maven.gnomecraft.net/releases" }
 }
 
 dependencies {

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -101,7 +101,8 @@ repositories {
     maven { url = "https://maven.ladysnake.org/releases" }
     maven { url "https://mvn.devos.one/snapshots/" }
     // EMI
-    maven { url = "https://maven.terraformersmc.com/releases/" }
+    // temporarily changed from https://maven.terraformersmc.com/releases/ due to intermittent errors
+    maven { url = "https://maven.gnomecraft.net/releases" }
     exclusiveContent {
         forRepository {
             maven { url = "https://api.modrinth.com/maven" }

--- a/Neoforge/build.gradle
+++ b/Neoforge/build.gradle
@@ -68,7 +68,8 @@ repositories {
     // pehkui
     maven { url = "https://jitpack.io" }
     // EMI
-    maven { url = "https://maven.terraformersmc.com/releases/" }
+    // temporarily changed from https://maven.terraformersmc.com/releases/ due to intermittent errors
+    maven { url = "https://maven.gnomecraft.net/releases" }
 
     maven {
         name = 'Kotlin for Forge'


### PR DESCRIPTION
This fixes the intermittent build failures caused by https://maven.terraformersmc.com/releases sometimes returning the following error:

```
Premature end of chunk coded message body: closing chunk expected
```

The new maven is a mirror run by a Terraformers team member.

This implements the same fix as #1204, but for the `1.21` branch. This will cause a merge conflict when we next merge `main` into `1.21`, but it'll be trivial to fix, and it's currently more important to fix these failures to unblock other work.