### PR TITLE
fix: pass string to Component.translatable instead of ResourceLocation

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/common/command/ListPerWorldPatternsCommand.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/command/ListPerWorldPatternsCommand.java
@@ -136,7 +136,7 @@ public class ListPerWorldPatternsCommand {
                 Component.translatable(
                     "command.hexcasting.pats.specific.success",
                     stack.getDisplayName(),
-                        actionKey.location(),
+                        actionKey.location().toString(),
                     targets.size() == 1 ? targets.iterator().next().getDisplayName() : targets.size()),
                 true);
 


### PR DESCRIPTION
Fixes #1150 

A resource location was incorrectly being passed directly to `Component.translate`, resulting in an error.