### PR TITLE
chore: change ravenmind type to Iota on client side

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/ExecutionClientView.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/ExecutionClientView.kt
@@ -2,7 +2,6 @@ package at.petrak.hexcasting.api.casting.eval
 
 import at.petrak.hexcasting.api.casting.iota.Iota
 import at.petrak.hexcasting.api.casting.iota.IotaType
-import net.minecraft.nbt.CompoundTag
 import net.minecraft.network.RegistryFriendlyByteBuf
 import net.minecraft.network.codec.ByteBufCodecs
 import net.minecraft.network.codec.StreamCodec
@@ -17,7 +16,7 @@ data class ExecutionClientView(
     val resolutionType: ResolvedPatternType,
 
     val stackDescs: List<Iota>,
-    val ravenmind: CompoundTag?
+    val ravenmind: Iota?
 ) {
 
     companion object {
@@ -30,9 +29,9 @@ data class ExecutionClientView(
                     ResolvedPatternType::ordinal
                 ), ExecutionClientView::resolutionType,
                 IotaType.TYPED_STREAM_CODEC.apply(ByteBufCodecs.list()), ExecutionClientView::stackDescs,
-                ByteBufCodecs.optional(ByteBufCodecs.COMPOUND_TAG).map(
+                ByteBufCodecs.optional(IotaType.TYPED_STREAM_CODEC).map(
                     { it.getOrNull() },
-                    Optional<CompoundTag>::ofNullable
+                    Optional<Iota>::ofNullable
                 ), ExecutionClientView::ravenmind,
                 ::ExecutionClientView
             )

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingImage.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingImage.kt
@@ -4,16 +4,17 @@ import at.petrak.hexcasting.api.HexAPI
 import at.petrak.hexcasting.api.casting.iota.Iota
 import at.petrak.hexcasting.api.casting.iota.IotaType
 import at.petrak.hexcasting.api.utils.TreeList
+import at.petrak.hexcasting.api.utils.compositeCodecSeven
 import at.petrak.hexcasting.api.utils.getOrCreateCompound
 import at.petrak.hexcasting.api.utils.putCompound
-import at.petrak.hexcasting.api.utils.compositeCodecSeven
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.nbt.CompoundTag
+import net.minecraft.nbt.NbtOps
 import net.minecraft.network.codec.ByteBufCodecs
 import net.minecraft.network.codec.StreamCodec
 import net.minecraft.world.entity.Entity
-import java.util.Optional
+import java.util.*
 
 /**
  * The state of a casting VM, containing the stack and all
@@ -80,11 +81,11 @@ data class CastingImage(
     /**
      * Returns this image's ravenmind in an Optional wrapper.
      */
-    fun ravenmind() : Optional<CompoundTag> {
+    fun ravenmind() : Optional<Iota> {
         val tag = userData.getCompound(HexAPI.RAVENMIND_USERDATA)
 
-        var result: CompoundTag? = null
-        if (!tag.isEmpty) { result = tag }
+        var result: Iota? = null
+        if (!tag.isEmpty) { result = IotaType.TYPED_CODEC.parse(NbtOps.INSTANCE, tag).getOrThrow() }
         return Optional.ofNullable(result)
     }
 

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingVM.kt
@@ -1,14 +1,14 @@
 package at.petrak.hexcasting.api.casting.eval.vm
 
-import at.petrak.hexcasting.api.HexAPI
-import at.petrak.hexcasting.api.casting.PatternShapeMatch.*
-import at.petrak.hexcasting.api.casting.eval.*
+import at.petrak.hexcasting.api.casting.eval.CastResult
+import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
+import at.petrak.hexcasting.api.casting.eval.ExecutionClientView
+import at.petrak.hexcasting.api.casting.eval.ResolvedPatternType
 import at.petrak.hexcasting.api.casting.eval.sideeffects.OperatorSideEffect
 import at.petrak.hexcasting.api.casting.eval.vm.CastingImage.ParenthesizedIota
 import at.petrak.hexcasting.api.casting.iota.BooleanIota
 import at.petrak.hexcasting.api.casting.iota.Iota
 import at.petrak.hexcasting.api.casting.iota.IotaType
-import at.petrak.hexcasting.api.casting.iota.ListIota
 import at.petrak.hexcasting.api.casting.iota.PatternIota
 import at.petrak.hexcasting.api.casting.math.HexDir
 import at.petrak.hexcasting.api.casting.math.HexPattern
@@ -20,11 +20,7 @@ import at.petrak.hexcasting.api.utils.TreeList
 import at.petrak.hexcasting.api.utils.validateIota
 import at.petrak.hexcasting.api.utils.validateIotaList
 import at.petrak.hexcasting.common.lib.hex.HexEvalSounds
-import net.minecraft.nbt.CompoundTag
-import net.minecraft.nbt.NbtOps
-import net.minecraft.nbt.Tag
 import net.minecraft.server.level.ServerLevel
-import kotlin.jvm.optionals.getOrElse
 import kotlin.jvm.optionals.getOrNull
 
 /**
@@ -105,12 +101,10 @@ class CastingVM(var image: CastingImage, val env: CastingEnvironment) {
                 if (lastResolutionType.success) ResolvedPatternType.EVALUATED else ResolvedPatternType.ERRORED
         }
 
-        var ravenmind: CompoundTag? = image.ravenmind().getOrNull()
+        var ravenmind: Iota? = image.ravenmind().getOrNull()
 
         if (ravenmind != null) {
-            val test = IotaType.TYPED_CODEC.parse<Tag?>(NbtOps.INSTANCE, ravenmind).getOrThrow()
-            val newIota = validateIota(test, world)
-            ravenmind = IotaType.TYPED_CODEC.encodeStart<Tag?>(NbtOps.INSTANCE, newIota).getOrThrow() as CompoundTag?
+            ravenmind = validateIota(ravenmind, world)
         }
 
         val isStackClear = image.stack.isEmpty()

--- a/Common/src/main/java/at/petrak/hexcasting/client/gui/GuiSpellcasting.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/client/gui/GuiSpellcasting.kt
@@ -4,7 +4,6 @@ import at.petrak.hexcasting.api.casting.eval.ExecutionClientView
 import at.petrak.hexcasting.api.casting.eval.ResolvedPattern
 import at.petrak.hexcasting.api.casting.eval.ResolvedPatternType
 import at.petrak.hexcasting.api.casting.iota.Iota
-import at.petrak.hexcasting.api.casting.iota.IotaType
 import at.petrak.hexcasting.api.casting.math.HexAngle
 import at.petrak.hexcasting.api.casting.math.HexCoord
 import at.petrak.hexcasting.api.casting.math.HexDir
@@ -31,8 +30,6 @@ import net.minecraft.client.gui.screens.Screen
 import net.minecraft.client.renderer.GameRenderer
 import net.minecraft.client.resources.sounds.SimpleSoundInstance
 import net.minecraft.client.resources.sounds.SoundInstance
-import net.minecraft.nbt.CompoundTag
-import net.minecraft.nbt.NbtOps
 import net.minecraft.sounds.SoundSource
 import net.minecraft.util.FormattedCharSequence
 import net.minecraft.util.Mth
@@ -45,7 +42,7 @@ class GuiSpellcasting constructor(
     private val handOpenedWith: InteractionHand,
     private var patterns: MutableList<ResolvedPattern>,
     private var cachedStack: List<Iota>,
-    private var cachedRavenmind: CompoundTag?,
+    private var cachedRavenmind: Iota?,
     private var parenCount: Int,
 ) : Screen("gui.hexcasting.spellcasting".asTranslatedComponent) {
     private var stackDescs: List<FormattedCharSequence> = listOf()
@@ -104,13 +101,10 @@ class GuiSpellcasting constructor(
 //            emptyList()
         this.parenDescs = emptyList()
         this.ravenmind =
-            this.cachedRavenmind?.let {
-                val iota = IotaType.TYPED_CODEC.parse(NbtOps.INSTANCE, it).getOrThrow()
-                iota.displayWithMaxWidth(
-                    (this.width * RHS_IOTAS_ALLOCATION).toInt(),
-                    mc.font
-                )
-            }
+            this.cachedRavenmind?.displayWithMaxWidth(
+                (this.width * RHS_IOTAS_ALLOCATION).toInt(),
+                mc.font
+            )
     }
 
     override fun init() {
@@ -209,7 +203,7 @@ class GuiSpellcasting constructor(
                 val angle = atan2(delta.y, delta.x)
                 // 0 is right, increases clockwise(?)
                 val snappedAngle = angle.div(Mth.TWO_PI).mod(6.0f)
-                val newdir = HexDir.values()[(snappedAngle.times(6).roundToInt() + 1).mod(6)]
+                val newdir = HexDir.entries[(snappedAngle.times(6).roundToInt() + 1).mod(6)]
                 // The player might have a lousy aim, so set the new anchor point to the "ideal"
                 // location as if they had hit it exactly on the nose.
                 val idealNextLoc = anchorCoord + newdir

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/local/OpPeekLocal.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/local/OpPeekLocal.kt
@@ -1,17 +1,12 @@
 package at.petrak.hexcasting.common.casting.actions.local
 
-import at.petrak.hexcasting.api.HexAPI
 import at.petrak.hexcasting.api.casting.castables.Action
 import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
 import at.petrak.hexcasting.api.casting.eval.OperationResult
 import at.petrak.hexcasting.api.casting.eval.vm.CastingImage
 import at.petrak.hexcasting.api.casting.eval.vm.SpellContinuation
-import at.petrak.hexcasting.api.casting.iota.GarbageIota
-import at.petrak.hexcasting.api.casting.iota.IotaType
 import at.petrak.hexcasting.api.casting.iota.NullIota
 import at.petrak.hexcasting.common.lib.hex.HexEvalSounds
-import net.minecraft.nbt.NbtOps
-import kotlin.jvm.optionals.getOrElse
 
 object OpPeekLocal : Action {
     override fun operate(env: CastingEnvironment, image: CastingImage, continuation: SpellContinuation): OperationResult {
@@ -19,7 +14,7 @@ object OpPeekLocal : Action {
         val stack = image.stack
 
         val rm = if (ravenmind.isPresent) {
-            IotaType.TYPED_CODEC.parse(NbtOps.INSTANCE, ravenmind.get()).orThrow
+            ravenmind.get()
         } else {
             NullIota()
         }

--- a/Common/src/main/java/at/petrak/hexcasting/common/items/ItemStaff.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/items/ItemStaff.java
@@ -1,12 +1,12 @@
 package at.petrak.hexcasting.common.items;
 
 import at.petrak.hexcasting.api.HexAPI;
+import at.petrak.hexcasting.api.casting.iota.Iota;
 import at.petrak.hexcasting.common.lib.HexAttributes;
 import at.petrak.hexcasting.common.lib.HexSounds;
 import at.petrak.hexcasting.common.msgs.MsgClearSpiralPatternsS2C;
 import at.petrak.hexcasting.common.msgs.MsgOpenSpellGuiS2C;
 import at.petrak.hexcasting.xplat.IXplatAbstractions;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.stats.Stats;
@@ -47,7 +47,7 @@ public class ItemStaff extends Item {
             var vm = IXplatAbstractions.INSTANCE.getStaffcastVM(serverPlayer, hand);
             var patterns = IXplatAbstractions.INSTANCE.getPatternsSavedInUi(serverPlayer);
 
-            @Nullable CompoundTag ravenmind = vm.getImage().ravenmind().orElse(null);
+            @Nullable Iota ravenmind = vm.getImage().ravenmind().orElse(null);
 
 
             IXplatAbstractions.INSTANCE.sendPacketToPlayer(serverPlayer,

--- a/Common/src/main/java/at/petrak/hexcasting/common/msgs/MsgOpenSpellGuiS2C.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/msgs/MsgOpenSpellGuiS2C.java
@@ -6,7 +6,6 @@ import at.petrak.hexcasting.api.casting.iota.Iota;
 import at.petrak.hexcasting.api.casting.iota.IotaType;
 import at.petrak.hexcasting.client.gui.GuiSpellcasting;
 import net.minecraft.client.Minecraft;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
@@ -23,7 +22,7 @@ import java.util.Optional;
 public record MsgOpenSpellGuiS2C(InteractionHand hand, List<ResolvedPattern> patterns,
                                  List<Iota> stack,
                                  @Nullable
-                                 CompoundTag ravenmind,
+                                 Iota ravenmind,
                                  int parenCount
 )
     implements CustomPacketPayload {
@@ -36,7 +35,7 @@ public record MsgOpenSpellGuiS2C(InteractionHand hand, List<ResolvedPattern> pat
             ), MsgOpenSpellGuiS2C::hand,
             ResolvedPattern.STREAM_CODEC.apply(ByteBufCodecs.list()), MsgOpenSpellGuiS2C::patterns,
             IotaType.TYPED_STREAM_CODEC.apply(ByteBufCodecs.list()), MsgOpenSpellGuiS2C::stack,
-            ByteBufCodecs.optional(ByteBufCodecs.COMPOUND_TAG).map(
+            ByteBufCodecs.optional(IotaType.TYPED_STREAM_CODEC).map(
                     opt -> opt.orElse(null),
                     Optional::ofNullable
             ), MsgOpenSpellGuiS2C::ravenmind,


### PR DESCRIPTION
Closes #1059 

Since Iotas can be used clientside after the 1.21 port, it makes sense to convert the Ravenmind to an Iota in all places for consistency.