### PR TITLE
Fix 1.21 CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -94,9 +94,9 @@ jobs:
           ${{ matrix.dependencies }}
           END_OF_FILE
 
-      - name: Cache dependencies
+      - name: Restore cached dependencies
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: run/mods
           key: ${{ hashFiles('dependencies.txt') }}
@@ -107,6 +107,13 @@ jobs:
           for url in ${{ matrix.dependencies }}; do
             wget --directory-prefix=run/mods/ "$url"
           done
+
+      - name: Cache dependencies
+        uses: actions/cache/save@v4
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: run/mods
+          key: ${{ hashFiles('dependencies.txt') }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -118,12 +118,18 @@ jobs:
           rm -f dist/*-javadoc.jar dist/*-sources.jar
           cp dist/hexcasting-${{ matrix.modloader }}-*.jar run/mods
 
+      - name: Shorten java version
+        shell: bash
+        id: shorten-java
+        run:
+          echo "shortened=${JAVA_VERSION%%.*}" >> $GITHUB_OUTPUT
+
       - name: Run MC test client
         if: matrix.env == 'client'
         timeout-minutes: 10
         uses: headlesshq/mc-runtime-test@4.5.1
         with:
-          java: ${{ env.JAVA_VERSION }}
+          java: ${{ steps.shorten-java.outputs.shortened }}
           mc: 1.21.1
           modloader: ${{ matrix.modloader }}
           regex: '.*${{ matrix.modloader }}.*'
@@ -135,7 +141,7 @@ jobs:
         timeout-minutes: 10
         uses: headlesshq/mc-server-test@1.1.1
         with:
-          java: 21
+          java: ${{ steps.shorten-java.outputs.shortened }}
           mc: 1.21.1
           modloader: ${{ matrix.modloader }}
           fabric-api: ${{ matrix.fabric-api }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Run MC test client
         if: matrix.env == 'client'
         timeout-minutes: 10
-        uses: headlesshq/mc-runtime-test@4.4.0
+        uses: headlesshq/mc-runtime-test@4.5.1
         with:
           java: ${{ env.JAVA_VERSION }}
           mc: 1.21.1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Prepare mod jar
         run: |
-          rm -f dist/*-javadoc.jar dist/*-sources.jar
+          rm -f dist/*-javadoc.jar dist/*-sources.jar dist/*-shadow.jar
           cp dist/hexcasting-${{ matrix.modloader }}-*.jar run/mods
 
       - name: Shorten java version

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -146,6 +146,7 @@ jobs:
           mc: 1.21.1
           modloader: ${{ matrix.modloader }}
           fabric-api: ${{ matrix.fabric-api }}
+          hmc-version: 2.10.0
 
   datagen:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -94,7 +94,7 @@ jobs:
           cat <<END_OF_FILE > dependencies.txt
           ${{ matrix.dependencies }}
           END_OF_FILE
-          echo "key=$(sha256sum dependencies.txt)" >> $GITHUB_OUTPUT
+          echo "key=$(sha256sum dependencies.txt | awk '{print $1}')" >> $GITHUB_OUTPUT
       - name: Restore cached dependencies
         id: cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,7 +62,7 @@ jobs:
             dependencies: >-
               'https://cdn.modrinth.com/data/Ha28R6CL/versions/2i87JpYj/fabric-language-kotlin-1.13.11%2Bkotlin.2.3.21.jar'
               'https://cdn.modrinth.com/data/9s6osm5g/versions/HpMb5wGb/cloth-config-15.0.140-fabric.jar'
-              'https://github.com/SuperKnux/HexMod/raw/refs/heads/indev/1.21.1/libs/paucal-0.7.1-noelle+1.21.1-fabric.jar'
+              'https://ci.blamejared.com/job/petrakat/job/PAUCAL/job/1.21/27/artifact/Fabric/build/libs/paucal-0.7.1-pre-27+1.21.1-fabric.jar'
               'https://cdn.modrinth.com/data/fin1PX4m/versions/SBDJBD0a/inline-fabric-1.21.1-1.2.2.jar'
               'https://cdn.modrinth.com/data/K01OU20C/versions/nLsCe2VD/cardinal-components-api-6.1.3.jar'
               'https://cdn.modrinth.com/data/nU0bVIaL/versions/XIjNwQkI/Patchouli-1.21.1-93-FABRIC.jar'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -68,6 +68,7 @@ jobs:
               'https://cdn.modrinth.com/data/nU0bVIaL/versions/XIjNwQkI/Patchouli-1.21.1-93-FABRIC.jar'
               'https://cdn.modrinth.com/data/mOgUt4GM/versions/v6Xx3fbU/modmenu-11.0.4.jar'
               'https://cdn.modrinth.com/data/5aaWibi9/versions/JagCscwi/trinkets-3.10.0.jar'
+              'https://cdn.modrinth.com/data/lhGA9TYQ/versions/Pzc2FP5K/architectury-13.0.11-fabric.jar'
           - modloader: neoforge
             mc-runtime-test: neoforge
             fabric-api: none

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -146,7 +146,6 @@ jobs:
           mc: 1.21.1
           modloader: ${{ matrix.modloader }}
           fabric-api: ${{ matrix.fabric-api }}
-          hmc-version: 2.10.0
 
   datagen:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ on:
     branches: indev/1.21.1
 
 env:
-  JAVA_VERSION: '21.0.5'
+  JAVA_VERSION: '21'
 
 jobs:
   build:
@@ -89,17 +89,18 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: Create cache key
+        id: cache-key
         run: |
           cat <<END_OF_FILE > dependencies.txt
           ${{ matrix.dependencies }}
           END_OF_FILE
-
+          echo "key=$(sha256sum dependencies.txt)" >> $GITHUB_OUTPUT
       - name: Restore cached dependencies
         id: cache
         uses: actions/cache/restore@v4
         with:
           path: run/mods
-          key: ${{ hashFiles('dependencies.txt') }}
+          key: ${{ steps.cache-key.outputs.key }}
 
       - name: Download dependencies
         if: steps.cache.outputs.cache-hit != 'true'
@@ -108,12 +109,13 @@ jobs:
             wget --directory-prefix=run/mods/ "$url"
           done
 
+      # Cache has to be saved here already to avoid also caching the build artifact at the end of the run
       - name: Cache dependencies
         uses: actions/cache/save@v4
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           path: run/mods
-          key: ${{ hashFiles('dependencies.txt') }}
+          key: ${{ steps.cache-key.outputs.key }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -126,18 +128,12 @@ jobs:
           rm -f dist/*-javadoc.jar dist/*-sources.jar dist/*-shadow.jar
           cp dist/hexcasting-${{ matrix.modloader }}-*.jar run/mods
 
-      - name: Shorten java version
-        shell: bash
-        id: shorten-java
-        run:
-          echo "shortened=${JAVA_VERSION%%.*}" >> $GITHUB_OUTPUT
-
       - name: Run MC test client
         if: matrix.env == 'client'
         timeout-minutes: 10
         uses: headlesshq/mc-runtime-test@4.5.1
         with:
-          java: ${{ steps.shorten-java.outputs.shortened }}
+          java: ${{ env.JAVA_VERSION }}
           mc: 1.21.1
           modloader: ${{ matrix.modloader }}
           regex: '.*${{ matrix.modloader }}.*'
@@ -149,7 +145,7 @@ jobs:
         timeout-minutes: 10
         uses: headlesshq/mc-server-test@1.1.1
         with:
-          java: ${{ steps.shorten-java.outputs.shortened }}
+          java: ${{ env.JAVA_VERSION }}
           mc: 1.21.1
           modloader: ${{ matrix.modloader }}
           fabric-api: ${{ matrix.fabric-api }}


### PR DESCRIPTION
Fixes #1074

There seemed to be multiple issues here:
- PAUCAL is relying on ArchitecturyAPI which was missing in the dependencies
- The PAUCAL version from SuperKnux' fork previously present in the dependencies caused an error on server start
- The unmapped *-shadow.jar files were copied to the mods folder together with the final mapped jar, causing the runs to non-deterministically fail depending on which file was loaded and which was ignored by the mod loader
- The mc-runtime-test action expects only the major java version, so it was failing with the full major.minor.patch format

I thought it was also worth reevaluating the mod caching of the testing workflow. This cache has thrown me for a loop multiple times while analyzing this issue, since the cached mods are all the mods present in the run/mods folder, not just the ones downloaded from the dependencies.txt. One possible way to avoid this would be to split the cache action call up into cache/restore and cache/save, saving the cache right after the dependency download instead of at the end of the job. I've included this solution into this PR, but feel free to let me know if this is not something you want.

Hexdoc still doesn't work, but this is tracked separately in #1072 