### PR TITLE
chore: remove PKPCPBP and use mod-publish-plugin

### DIFF
--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -8,31 +8,54 @@ architectury {
     fabric()
 }
 
-// FIXME: update dependencies/versions before releasing 0.12
-pkSubproj {
-    pkPublish = true
-    curseforgeJar = remapJar.archiveFile
-    curseforgeDependencies([
-        "paucal",
-        "patchouli",
-        "fabric-language-kotlin",
-        "inline",
-        "cloth-config",
-        "cardinal-components-api",
-        "fabric-api",
-    ])
-    modrinthJar = remapJar.archiveFile
-    modrinthDependencies([
-        "paucal:dabyDTwJ", // 0.6.0-fabric
-        "patchouli:1.20.1-80-fabric",
-        "fabric-language-kotlin:1.13.7+kotlin.2.2.21",
-        "inline:1.20.1-1.2.2-fabric",
-        "cloth-config:11.1.106+fabric",
-        "cardinal-components-api:5.2.1",
-        "fabric-api:0.84.0+1.20.1",
-    ])
-}
+publishMods {
+    // for Fabric 1.21.11 and below
+    file = remapJar.archiveFile
+    modLoaders.add("fabric")
+    curseforge{
+        requires("paucal",
+                "patchouli",
+                "fabric-language-kotlin",
+                "inline",
+                "cloth-config",
+                "cardinal-components-api",
+                "fabric-api",)
+    }
+    modrinth{
+        requires {
+            slug = "paucal"
+            version = "6xwATRVY" // 0.7.0 fabric ver
+        }
+        requires {
+            slug = "patchouli"
+            version = "1.21-88-fabric"
+        }
 
+        requires {
+            slug = "fabric-language-kotlin"
+            version = fabricLanguageKotlinVersion
+        }
+
+        requires {
+            slug = "inline"
+            version = "1.21.1-1.2.2-fabric"
+        }
+
+        requires {
+            slug = "cloth-config"
+            version = clothConfigVersion + "+fabric"
+        }
+        requires {
+            slug = "cardinal-components-api"
+            version = cardinalComponentsVersion
+        }
+        requires {
+            slug = "fabric-api"
+            version = fabricVersion
+        }
+
+    }
+}
 
 loom {
     mixin.defaultRefmapName = "hexcasting.mixins.refmap.json"

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -13,13 +13,15 @@ publishMods {
     file = remapJar.archiveFile
     modLoaders.add("fabric")
     curseforge{
-        requires("paucal",
-                "patchouli",
-                "fabric-language-kotlin",
-                "inline",
-                "cloth-config",
-                "cardinal-components-api",
-                "fabric-api",)
+        requires(
+            "paucal",
+            "patchouli",
+            "fabric-language-kotlin",
+            "inline",
+            "cloth-config",
+            "cardinal-components-api",
+            "fabric-api",
+        )
     }
     modrinth{
         requires {
@@ -53,7 +55,6 @@ publishMods {
             slug = "fabric-api"
             version = fabricVersion
         }
-
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,18 @@
 #!/usr/bin/env groovy
 
+RELEASE_BRANCHES = ["main", "1.21"]
+
 pipeline {
     agent any
     tools {
         jdk "jdk-21"
+    }
+    parameters {
+        booleanParam(
+            name: "PUBLISH_CURSEFORGE_AND_MODRINTH",
+            description: "Publish to CurseForge and modrinth",
+            defaultValue: false,
+        )
     }
     environment {
         discordWebhook = credentials('discordWebhook')
@@ -43,7 +52,7 @@ pipeline {
         stage('Publish') {
             when {
                 allOf {
-                    branch 'main'
+                    expression { env.BRANCH_NAME in RELEASE_BRANCHES }
                     not { changeRequest() }
                 }
             }
@@ -51,10 +60,13 @@ pipeline {
                 stage('Deploy Previews') {
                     steps {
                         echo 'Deploying previews to various places'
-                        sh './gradlew publish publishToDiscord'
+                        sh './gradlew publish announceDiscord'
                     }
                 }
                 stage('Deploy releases') {
+                    when {
+                        expression { params.CURSEFORGE_AND_MODRINTH}
+                    }
                     steps {
                         echo 'Maybe deploy releases'
                         sh './gradlew publishCurseforge publishModrinth'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,11 +13,17 @@ pipeline {
             description: "Publish to CurseForge and modrinth",
             defaultValue: false,
         )
+        booleanParam(
+            name: "FORMAL_RELEASE",
+            description: "decides if is a formal release (without -pre)",
+            defaultValue: false,
+        )
     }
     environment {
         discordWebhook = credentials('discordWebhook')
         CURSEFORGE_TOKEN = credentials('curseforgeApiKey')
         MODRINTH_TOKEN = credentials('modrinthApiKey')
+        FORMAL_RELEASE = "${params.FORMAL_RELEASE ? 'true' : 'false'}"
     }
     stages {
         stage('Clean') {
@@ -71,7 +77,7 @@ pipeline {
                         echo 'Maybe deploy releases'
                         sh './gradlew publishCurseforge publishModrinth'
                     }
-                }
+                }}
             }
         }
     }

--- a/Neoforge/build.gradle
+++ b/Neoforge/build.gradle
@@ -8,23 +8,34 @@ architectury {
     neoForge()
 }
 
-// FIXME: update dependencies/versions before releasing 0.12
-pkSubproj {
-    pkPublish = true
-    curseforgeJar = jar.archiveFile
-    curseforgeDependencies([
-        "paucal",
-        "patchouli",
-        "caelus",
-        "inline",
-    ])
-    modrinthJar = jar.archiveFile
-    modrinthDependencies([
-        "paucal:HyBiJPtT", // 0.6.0-forge
-        "patchouli:1.20.1-80-forge",
-        "caelus:3.1.0+1.20",
-        "inline:1.20.1-1.0.1-forge",
-    ])
+publishMods {
+    file = jar.archiveFile
+    modLoaders.add("neoForge")
+    curseforge{
+        requires("paucal",
+                "patchouli",
+                "caelus",
+                "inline")
+    }
+    modrinth{
+        requires {
+            slug = "paucal"
+            version = "zgpdzVKd"
+            platform = "neoforge"
+        }
+        requires {
+            slug = "patchouli"
+            version = "1.21-88-neoforge"
+        }
+        requires {
+            slug = "caelus"
+            version = "KsfI4QsR" // 7.0.1+1.21.1 neoforge ver
+        }
+        requires {
+            slug = "inline"
+            version = "1.21.1-1.2.2-neoforge"
+        }
+    }
 }
 
 configurations {
@@ -55,7 +66,7 @@ repositories {
     }
 
     maven { url = "https://maven.neoforged.net/releases/" }
-    // paucal and patchi
+    // paucal and patchouli
     maven { url = 'https://maven.blamejared.com' }
     maven {
         name = "Curios"

--- a/Neoforge/build.gradle
+++ b/Neoforge/build.gradle
@@ -12,10 +12,12 @@ publishMods {
     file = jar.archiveFile
     modLoaders.add("neoForge")
     curseforge{
-        requires("paucal",
-                "patchouli",
-                "caelus",
-                "inline")
+        requires(
+            "paucal",
+            "patchouli",
+            "caelus",
+            "inline"
+        )
     }
     modrinth{
         requires {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,8 @@ subprojects { subproject ->
     base.archivesName = "$modID-$platform-$minecraftVersion"
     version = modVersion
 
-    def isRelease = true
+    def isRelease = System.getenv("FORMAL_RELEASE") ?
+            System.getenv("FORMAL_RELEASE").toBoolean() : false
     def buildNumber = System.getenv("BUILD_NUMBER")
     if (!isRelease && buildNumber != null) {
         version += "-pre-$buildNumber"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import at.petrak.pkpcpbp.MiscUtil
-
 plugins {
     // used for something??
     id 'dev.architectury.loom' version '1.13-SNAPSHOT' apply false
@@ -14,38 +12,30 @@ plugins {
     // Also it looks like property lookups don't work this early
     id 'fabric-loom' version '1.9+' apply false
 
-    id("at.petra-k.pkpcpbp.PKPlugin") version "0.2.0-pre-104"
-    id("at.petra-k.pkpcpbp.PKSubprojPlugin") version "0.2.0-pre-104" apply false
-    id("at.petra-k.pkpcpbp.PKJson5Plugin") version "0.2.0-pre-104" apply false
+    id "me.modmuss50.mod-publish-plugin" version "2.1.1"
+    id "coffee.cypher.json-processor" version "0.1.0" apply false
 }
 
 architectury {
     minecraft = project.minecraftVersion
 }
 
-pkpcpbp {
-    // if something goes wrong in CI, make sure we can see the logs to figure out why
-    superDebugInfo = System.getenv("CI") != null
-    // we set the maven coordinates manually in the subprojects block
-    doProjectMetadata = false
-    setupJarMetadata = true
-    setupMavenMetadata = true
-    javaVersion = 21
-    modInfo {
-        modID = project.modID
-        mcVersion = project.minecraftVersion
-        modVersion = project.modVersion
-    }
-    curseforgeInfo {
-        id = 569849
-        stability = "beta"
-        token = System.getenv("CURSEFORGE_TOKEN")
-    }
-    modrinthInfo {
-        id = "nTW3yKrm"
-        stability = "beta"
-        token = System.getenv("MODRINTH_TOKEN")
-    }
+// Determine release status from the HEAD commit subject, mirroring PKPCPBP's
+// MiscUtil.isRelease(getMostRecentPush(...)): a release is any commit whose
+// subject starts with "[release" (case-insensitive).
+def rootRecentCommit = ""
+def rootIsRelease = false
+try {
+    def proc = ["git", "log", "--pretty=tformat:%s", "-n", "1"].execute(null, rootProject.projectDir)
+    proc.waitFor()
+    rootRecentCommit = proc.text.trim()
+    rootIsRelease = rootRecentCommit ==~ /(?i)^\[release.*/
+} catch (Exception e) {
+    logger.warn("Could not determine release status from git: {}", e.toString())
+}
+
+kotlin {
+    jvmToolchain(21)
 }
 
 subprojects {
@@ -54,28 +44,55 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'kotlin'
     apply plugin: 'maven-publish'
-    apply plugin: 'at.petra-k.pkpcpbp.PKSubprojPlugin'
-    apply plugin: 'at.petra-k.pkpcpbp.PKJson5Plugin'
+    apply plugin: 'me.modmuss50.mod-publish-plugin'
+    apply plugin: 'coffee.cypher.json-processor'
 
     group = "at.petra-k.$modID"
     base.archivesName = "$modID-$platform-$minecraftVersion"
     version = modVersion
 
-    def isRelease = MiscUtil.isRelease(MiscUtil.getMostRecentPush(project))
+    def isRelease = rootIsRelease
     def buildNumber = System.getenv("BUILD_NUMBER")
     if (!isRelease && buildNumber != null) {
         version += "-pre-$buildNumber"
     }
 
-    pkSubproj {
-        platform = project.platform
-        artifactId = base.archivesName.get()
-        versionDisplayName = "$platform-$minecraftVersion-$modVersion"
+    kotlin {
+        jvmToolchain(21)
     }
 
-    pkJson5 {
-        autoProcessJson5 = true
-        autoProcessJson5Flattening = true
+//    pkSubproj {
+//        platform = project.platform
+//        artifactId = base.archivesName.get()
+//        versionDisplayName = "$platform-$minecraftVersion-$modVersion"
+//    }
+    // Exposed so each platform subproject's publishMods {} block can reference them.
+    ext.isRelease = isRelease
+    ext.modChangelog = "# " + rootRecentCommit
+
+    // JSON5 processing (replaces PKJson5): .flatten.json5 is flattened + converted
+    // to .json; plain .json5 is converted to .json. Flattening joins nested keys
+    // with "." unless the accumulated prefix ends with ":", "_", "-", or "/".
+    processResources {
+        filesMatching(['assets/**/*.json5', 'data/**/*.json5']) {
+            def isFlatten = name.endsWith('.flatten.json5')
+            name = isFlatten ? name.replace('.flatten.json5', '.json') : name.replace('.json5', '.json')
+            processJson {
+                if (isFlatten) {
+                    pipeline {
+                        flatten {
+                            keyDelimiter = '.'
+                            skipDelimiterAfter(':', '_', '-', '/')
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Only run mod-publishing tasks on actual releases (mirrors PKPCPBP gating).
+    tasks.matching { it.name in ['publishCurseforge', 'publishModrinth', 'publishMods'] }.configureEach {
+        onlyIf { project.ext.isRelease }
     }
 
     loom {
@@ -130,6 +147,23 @@ subprojects {
             forRepository {
                 flatDir { dir(rootProject.file("libs")) }
             }
+        }
+    }
+    publishMods {
+        type = BETA
+        changelog = rootRecentCommit
+
+        modrinth {
+            accessToken = providers.environmentVariable("MODRINTH_TOKEN")
+            projectId = "nTW3yKrm"
+            minecraftVersions.add("1.21.1")
+        }
+        curseforge {
+            accessToken = providers.environmentVariable("CURSEFORGE_TOKEN")
+            projectId = "569849"
+            minecraftVersions.add("1.21.1")
+            client = true
+            server = true
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,46 +12,29 @@ plugins {
     // Also it looks like property lookups don't work this early
     id 'fabric-loom' version '1.9+' apply false
 
-    id "me.modmuss50.mod-publish-plugin" version "2.1.1"
-    id "coffee.cypher.json-processor" version "0.1.0" apply false
+    id("at.petra-k.pkpcpbp.PKJson5Plugin") version "0.2.0-pre-104" apply false
+    id "me.modmuss50.mod-publish-plugin"
 }
 
 architectury {
     minecraft = project.minecraftVersion
 }
 
-// Determine release status from the HEAD commit subject, mirroring PKPCPBP's
-// MiscUtil.isRelease(getMostRecentPush(...)): a release is any commit whose
-// subject starts with "[release" (case-insensitive).
-def rootRecentCommit = ""
-def rootIsRelease = false
-try {
-    def proc = ["git", "log", "--pretty=tformat:%s", "-n", "1"].execute(null, rootProject.projectDir)
-    proc.waitFor()
-    rootRecentCommit = proc.text.trim()
-    rootIsRelease = rootRecentCommit ==~ /(?i)^\[release.*/
-} catch (Exception e) {
-    logger.warn("Could not determine release status from git: {}", e.toString())
-}
-
-kotlin {
-    jvmToolchain(21)
-}
-
-subprojects {
+subprojects { subproject ->
     apply plugin: 'dev.architectury.loom'
     apply plugin: 'architectury-plugin'
     apply plugin: 'java'
     apply plugin: 'kotlin'
     apply plugin: 'maven-publish'
-    apply plugin: 'me.modmuss50.mod-publish-plugin'
-    apply plugin: 'coffee.cypher.json-processor'
-
+    apply plugin: 'at.petra-k.pkpcpbp.PKJson5Plugin'
+    if(subproject.path != ":Common") {
+        apply plugin: 'me.modmuss50.mod-publish-plugin'
+    }
     group = "at.petra-k.$modID"
     base.archivesName = "$modID-$platform-$minecraftVersion"
     version = modVersion
 
-    def isRelease = rootIsRelease
+    def isRelease = true
     def buildNumber = System.getenv("BUILD_NUMBER")
     if (!isRelease && buildNumber != null) {
         version += "-pre-$buildNumber"
@@ -61,38 +44,9 @@ subprojects {
         jvmToolchain(21)
     }
 
-//    pkSubproj {
-//        platform = project.platform
-//        artifactId = base.archivesName.get()
-//        versionDisplayName = "$platform-$minecraftVersion-$modVersion"
-//    }
-    // Exposed so each platform subproject's publishMods {} block can reference them.
-    ext.isRelease = isRelease
-    ext.modChangelog = "# " + rootRecentCommit
-
-    // JSON5 processing (replaces PKJson5): .flatten.json5 is flattened + converted
-    // to .json; plain .json5 is converted to .json. Flattening joins nested keys
-    // with "." unless the accumulated prefix ends with ":", "_", "-", or "/".
-    processResources {
-        filesMatching(['assets/**/*.json5', 'data/**/*.json5']) {
-            def isFlatten = name.endsWith('.flatten.json5')
-            name = isFlatten ? name.replace('.flatten.json5', '.json') : name.replace('.json5', '.json')
-            processJson {
-                if (isFlatten) {
-                    pipeline {
-                        flatten {
-                            keyDelimiter = '.'
-                            skipDelimiterAfter(':', '_', '-', '/')
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    // Only run mod-publishing tasks on actual releases (mirrors PKPCPBP gating).
-    tasks.matching { it.name in ['publishCurseforge', 'publishModrinth', 'publishMods'] }.configureEach {
-        onlyIf { project.ext.isRelease }
+    pkJson5 {
+        autoProcessJson5 = true
+        autoProcessJson5Flattening = true
     }
 
     loom {
@@ -149,21 +103,26 @@ subprojects {
             }
         }
     }
-    publishMods {
-        type = BETA
-        changelog = rootRecentCommit
+    if(subproject.path != ":Common") {
+        publishMods {
+            type = BETA
+            changelog = ""
 
-        modrinth {
-            accessToken = providers.environmentVariable("MODRINTH_TOKEN")
-            projectId = "nTW3yKrm"
-            minecraftVersions.add("1.21.1")
-        }
-        curseforge {
-            accessToken = providers.environmentVariable("CURSEFORGE_TOKEN")
-            projectId = "569849"
-            minecraftVersions.add("1.21.1")
-            client = true
-            server = true
+            modrinth {
+                accessToken = providers.environmentVariable("MODRINTH_TOKEN")
+                projectId = "nTW3yKrm"
+                minecraftVersions.add("1.21.1")
+            }
+            curseforge {
+                accessToken = providers.environmentVariable("CURSEFORGE_TOKEN")
+                projectId = "569849"
+                minecraftVersions.add("1.21.1")
+                client = true
+                server = true
+            }
+            discord {
+                webhookUrl = providers.environmentVariable("discordWebhook")
+            }
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,8 +15,7 @@ pluginManagement {
 
     plugins {
         id "org.jetbrains.kotlin.jvm" version kotlinVersion
-        id "me.modmuss50.mod-publish-plugin" version "1.1.0"
-        id "coffee.cypher.json-processor" version "0.1.0"
+        id "me.modmuss50.mod-publish-plugin" version "2.1.1"
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,8 @@ pluginManagement {
 
     plugins {
         id "org.jetbrains.kotlin.jvm" version kotlinVersion
+        id "me.modmuss50.mod-publish-plugin" version "1.1.0"
+        id "coffee.cypher.json-processor" version "0.1.0"
     }
 }
 


### PR DESCRIPTION
note that publish only triggers when last commit starts with "[release" (case-insensitive) 

also, due to the inconsistent of maven version and modrinth version, alongside modrinth strange and crude match mechanism, this version of build.gradle still needs manually specify more than a half of dependency's version. 