### PR TITLE
Fix issues with circle bounds

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/CircleExecutionState.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/circles/CircleExecutionState.java
@@ -60,7 +60,7 @@ public class CircleExecutionState {
 
     protected CircleExecutionState(BlockPos impetusPos, Direction impetusDir, HashSet<BlockPos> reachedPositions,
        BlockPos currentPos, Direction enteredFrom, CastingImage currentImage, @Nullable UUID caster,
-       @Nullable FrozenPigment casterPigment, Long reachedSlate, BlockPos greaterCorner, BlockPos lesserPos) {
+       @Nullable FrozenPigment casterPigment, Long reachedSlate, BlockPos greaterCorner, BlockPos lesserCorner) {
         this.impetusPos = impetusPos;
         this.impetusDir = impetusDir;
         this.reachedPositions = reachedPositions;
@@ -72,8 +72,8 @@ public class CircleExecutionState {
         this.reachedSlate = reachedSlate;
 
         this.greaterCorner = greaterCorner;
-        this.lesserCorner = lesserPos;
-        this.bounds = new BlockBox(greaterCorner, lesserPos);
+        this.lesserCorner = lesserCorner;
+        this.bounds = new BlockBox(greaterCorner, lesserCorner);
     }
 
     public @Nullable ServerPlayer getCaster(ServerLevel world) {
@@ -165,7 +165,7 @@ public class CircleExecutionState {
             new CircleExecutionState(impetus.getBlockPos(), impetus.getStartDirection(),
                 reachedPositions, impetus.getBlockPos().offset(impetus.getStartDirection().getNormal()),
                 impetus.getStartDirection(), new CastingImage(), casterUUID, colorizer, 0L,
-                positiveBlock.move(1,1,1), negativeBlock));
+                positiveBlock, negativeBlock));
     }
 
     public CompoundTag save() {

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/circles/OpCircleBounds.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/circles/OpCircleBounds.kt
@@ -16,11 +16,11 @@ class OpCircleBounds(val max: Boolean) : ConstMediaAction {
             throw MishapNoSpellCircle()
         val circle = env.impetus ?: throw MishapNoSpellCircle()
 
-        val aabb = circle.executionState!!.bounds // the circle should have an execution state since it's executing this.
+        val boundsBox = circle.executionState!!.bounds // the circle should have an execution state since it's executing this.
 
         return if (max)
-            aabb.aabb().maxPosition.asActionResult
+            boundsBox.max().asActionResult
         else
-            aabb.aabb().minPosition.asActionResult
+            boundsBox.min().asActionResult
     }
 }

--- a/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
+++ b/Common/src/main/resources/assets/hexcasting/lang/en_us.flatten.json5
@@ -2029,8 +2029,8 @@
 
         "circle/impetus_pos": "Returns the position of the $(l:greatwork/impetus)$(item)Impetus/$ of this spell circle.",
         "circle/impetus_dir": "Returns the direction the $(l:greatwork/impetus)$(item)Impetus/$ of this spell circle is facing as a unit vector.",
-        "circle/bounds/min": "Returns the position of the lower-north-west corner of the bounds of this spell circle.",
-        "circle/bounds/max": "Returns the position of the upper-south-east corner of the bounds of this spell circle.",
+        "circle/bounds/min": "Returns the position of the block at the lower-north-west corner of this spell circle's bounds.",
+        "circle/bounds/max": "Returns the position of the block at the upper-south-east corner of this spell circle's bounds.",
       },
       
       akashic_patterns: {


### PR DESCRIPTION
At some point in the 1.21 port the `CircleExecutionState.bounds` value was changed from an `AABB` to a `BlockBox`. The `BlockBox` constructor does not need the one-block adjustment that the `AABB` constructor did in 1.20, so the presence of that adjustment was making the box one block too big.

Also, likely as part of the change to using `BlockBox`, the fold reflection patterns had been changed to return the actual corner positions of the bounds region, rather than the center of the corner blocks as in 1.20. This caused unexpected results when trying to use them to target blocks at the corners of the circle, since the game would have to determine which block to target given a position perfectly equidistant from 8 of them.

This PR fixes both of those problems, and also updates the guidebook descriptions for the fold reflections to clarify that they return the center positions of the corner blocks, rather than the actual corner positions.