### PR TITLE
Fix most kotlin warnings

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/castables/SpellAction.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/castables/SpellAction.kt
@@ -17,9 +17,9 @@ import net.minecraft.nbt.CompoundTag
 interface SpellAction : Action {
     val argc: Int
 
-    fun hasCastingSound(ctx: CastingEnvironment): Boolean = true
+    fun hasCastingSound(env: CastingEnvironment): Boolean = true
 
-    fun awardsCastingStat(ctx: CastingEnvironment): Boolean = true
+    fun awardsCastingStat(env: CastingEnvironment): Boolean = true
 
     @Throws(Mishap::class)
     fun execute(

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingImage.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/eval/vm/CastingImage.kt
@@ -16,7 +16,7 @@ import net.minecraft.world.entity.Entity
 /**
  * The state of a casting VM, containing the stack and all
  */
-data class CastingImage private constructor(
+data class CastingImage(
     val stack: List<Iota>,
 
     val parenCount: Int,

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/Mishap.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/Mishap.kt
@@ -22,16 +22,16 @@ import java.lang.RuntimeException
 
 abstract class Mishap : RuntimeException() {
     /** Mishaps spray half-red, half-this-color. */
-    abstract fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment
+    abstract fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment
 
-    open fun particleSpray(ctx: CastingEnvironment): ParticleSpray {
+    open fun particleSpray(env: CastingEnvironment): ParticleSpray {
         return ParticleSpray(
-            ctx.mishapSprayPos().add(0.0, 0.2, 0.0),
+            env.mishapSprayPos().add(0.0, 0.2, 0.0),
             Vec3(0.0, 2.0, 0.0),
             0.2, Math.PI / 4, 40)
     }
 
-    open fun resolutionType(ctx: CastingEnvironment): ResolvedPatternType = ResolvedPatternType.ERRORED
+    open fun resolutionType(env: CastingEnvironment): ResolvedPatternType = ResolvedPatternType.ERRORED
 
     /**
      * Execute the actual effect, not any sfx.
@@ -40,21 +40,21 @@ abstract class Mishap : RuntimeException() {
      */
     abstract fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>)
 
-    protected abstract fun errorMessage(ctx: CastingEnvironment, errorCtx: Context): Component?
+    protected abstract fun errorMessage(env: CastingEnvironment, errorCtx: Context): Component?
 
-    fun executeReturnStack(ctx: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>): List<Iota> {
-        execute(ctx, errorCtx, stack)
+    fun executeReturnStack(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>): List<Iota> {
+        execute(env, errorCtx, stack)
         return stack
     }
 
     /**
      * Every error message should be prefixed with the name of the action...
      */
-    fun errorMessageWithName(ctx: CastingEnvironment, errorCtx: Context): Component? {
+    fun errorMessageWithName(env: CastingEnvironment, errorCtx: Context): Component? {
         return if (errorCtx.name != null) {
-            "hexcasting.mishap".asTranslatedComponent(errorCtx.name, this.errorMessage(ctx, errorCtx) ?: return null)
+            "hexcasting.mishap".asTranslatedComponent(errorCtx.name, this.errorMessage(env, errorCtx) ?: return null)
         } else {
-            this.errorMessage(ctx, errorCtx)
+            this.errorMessage(env, errorCtx)
         }
     }
 
@@ -72,8 +72,8 @@ abstract class Mishap : RuntimeException() {
     protected fun actionName(name: Component?): Component =
         name ?: "hexcasting.spell.null".asTranslatedComponent.lightPurple
 
-    protected fun blockAtPos(ctx: CastingEnvironment, pos: BlockPos): Component {
-        return ctx.world.getBlockState(pos).block.name
+    protected fun blockAtPos(env: CastingEnvironment, pos: BlockPos): Component {
+        return env.world.getBlockState(pos).block.name
     }
 
     data class Context(val pattern: HexPattern?, val name: Component?)

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapAlreadyBrainswept.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapAlreadyBrainswept.kt
@@ -9,17 +9,17 @@ import net.minecraft.world.entity.Mob
 import net.minecraft.world.item.DyeColor
 
 class MishapAlreadyBrainswept(val mob: Mob) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.GREEN)
 
-    override fun execute(ctx: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
-        mob.hurt(mob.damageSources().source(HexDamageTypes.OVERCAST, ctx.castingEntity), mob.health)
+    override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
+        mob.hurt(mob.damageSources().source(HexDamageTypes.OVERCAST, env.castingEntity), mob.health)
     }
 
-    override fun particleSpray(ctx: CastingEnvironment) =
+    override fun particleSpray(env: CastingEnvironment) =
         ParticleSpray.burst(mob.eyePosition, 1.0)
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) =
         error("already_brainswept")
 
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapBadBlock.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapBadBlock.kt
@@ -13,18 +13,18 @@ import net.minecraft.world.level.Level
 import net.minecraft.world.phys.Vec3
 
 class MishapBadBlock(val pos: BlockPos, val expected: Component) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.LIME)
 
-    override fun execute(ctx: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
-        ctx.world.explode(null, pos.x + 0.5, pos.y + 0.5, pos.z + 0.5, 0.25f, Level.ExplosionInteraction.NONE)
+    override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
+        env.world.explode(null, pos.x + 0.5, pos.y + 0.5, pos.z + 0.5, 0.25f, Level.ExplosionInteraction.NONE)
     }
 
-    override fun particleSpray(ctx: CastingEnvironment) =
+    override fun particleSpray(env: CastingEnvironment) =
         ParticleSpray.burst(Vec3.atCenterOf(pos), 1.0)
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
-        error("bad_block", expected, this.pos.toShortString(), blockAtPos(ctx, this.pos))
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) =
+        error("bad_block", expected, this.pos.toShortString(), blockAtPos(env, this.pos))
 
     companion object {
         @JvmStatic

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapBadBrainsweep.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapBadBrainsweep.kt
@@ -11,17 +11,17 @@ import net.minecraft.world.item.DyeColor
 import net.minecraft.world.phys.Vec3
 
 class MishapBadBrainsweep(val mob: Mob, val pos: BlockPos) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.GREEN)
 
-    override fun execute(ctx: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
-        trulyHurt(mob, mob.damageSources().source(HexDamageTypes.OVERCAST, ctx.castingEntity), 1f)
+    override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
+        trulyHurt(mob, mob.damageSources().source(HexDamageTypes.OVERCAST, env.castingEntity), 1f)
     }
 
-    override fun particleSpray(ctx: CastingEnvironment): ParticleSpray {
+    override fun particleSpray(env: CastingEnvironment): ParticleSpray {
         return ParticleSpray.burst(Vec3.atCenterOf(pos), 1.0)
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
-        error("bad_brainsweep", blockAtPos(ctx, this.pos))
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) =
+        error("bad_brainsweep", blockAtPos(env, this.pos))
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapBadCaster.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapBadCaster.kt
@@ -6,12 +6,12 @@ import at.petrak.hexcasting.api.pigment.FrozenPigment
 import net.minecraft.world.item.DyeColor
 
 class MishapBadCaster: Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.RED)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) =
         error("bad_caster")
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapBadEntity.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapBadEntity.kt
@@ -11,14 +11,14 @@ import net.minecraft.world.entity.item.ItemEntity
 import net.minecraft.world.item.DyeColor
 
 class MishapBadEntity(val entity: Entity, val wanted: Component) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.BROWN)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         env.mishapEnvironment.yeetHeldItemsTowards(entity.position())
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) =
         error("bad_entity", wanted, entity.displayName.plainCopy().aqua)
 
     companion object {

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapBadItem.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapBadItem.kt
@@ -9,14 +9,14 @@ import net.minecraft.world.entity.item.ItemEntity
 import net.minecraft.world.item.DyeColor
 
 class MishapBadItem(val item: ItemEntity, val wanted: Component) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.BROWN)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         item.deltaMovement = item.deltaMovement.add((Math.random() - 0.5) * 0.05, 0.75, (Math.random() - 0.5) * 0.05)
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) = if (item.item.isEmpty)
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) = if (item.item.isEmpty)
         error("no_item", wanted)
     else
         error("bad_item", wanted, item.item.count, item.item.displayName)

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapBadLocation.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapBadLocation.kt
@@ -9,13 +9,13 @@ import net.minecraft.world.item.DyeColor
 import net.minecraft.world.phys.Vec3
 
 class MishapBadLocation(val location: Vec3, val type: String = "too_far") : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.MAGENTA)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         env.mishapEnvironment.yeetHeldItemsTowards(this.location)
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context): Component =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context): Component =
         error("location_$type", Vec3Iota.display(location))
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapBadOffhandItem.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapBadOffhandItem.kt
@@ -10,14 +10,14 @@ import net.minecraft.world.item.DyeColor
 import net.minecraft.world.item.ItemStack
 
 class MishapBadOffhandItem(val item: ItemStack?, val wanted: Component) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.BROWN)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         env.mishapEnvironment.dropHeldItems()
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) = if (item?.isEmpty == false)
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) = if (item?.isEmpty == false)
         error("bad_item.offhand", wanted, item.count, item.displayName)
     else
         error("no_item.offhand", wanted)

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapDisallowedSpell.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapDisallowedSpell.kt
@@ -13,16 +13,16 @@ class MishapDisallowedSpell(val type: String, val actionKey: ResourceLocation?) 
     @Deprecated("Provide the type (disallowed or disallowed_circle) and the action key that caused the mishap")
     constructor(type: String = "disallowed") : this(type, null) {}
 
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.BLACK)
 
-    override fun resolutionType(ctx: CastingEnvironment) = ResolvedPatternType.INVALID
+    override fun resolutionType(env: CastingEnvironment) = ResolvedPatternType.INVALID
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         // NO-OP
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context): Component? {
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context): Component? {
         if (actionKey == null) return error(type + "_generic")
         return error(type, "hexcasting.action.$actionKey".asTranslatedComponent)
     }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapDivideByZero.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapDivideByZero.kt
@@ -13,7 +13,7 @@ import net.minecraft.world.phys.Vec3
 
 class MishapDivideByZero(val operand1: Component, val operand2: Component, val suffix: String = "divide") : Mishap() {
 
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.RED)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
@@ -21,7 +21,7 @@ class MishapDivideByZero(val operand1: Component, val operand2: Component, val s
         env.mishapEnvironment.damage(0.5f)
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) =
         error("divide_by_zero.$suffix", operand1, operand2)
 
     companion object {

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapEntityTooFarAway.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapEntityTooFarAway.kt
@@ -8,13 +8,13 @@ import net.minecraft.world.entity.Entity
 import net.minecraft.world.item.DyeColor
 
 class MishapEntityTooFarAway(val entity: Entity) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.PINK)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         env.mishapEnvironment.yeetHeldItemsTowards(entity.position())
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context): Component =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context): Component =
         error("entity_too_far", entity.displayName)
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapEvalTooMuch.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapEvalTooMuch.kt
@@ -6,13 +6,13 @@ import at.petrak.hexcasting.api.pigment.FrozenPigment
 import net.minecraft.world.item.DyeColor
 
 class MishapEvalTooMuch : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.BLUE)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         env.mishapEnvironment.drown()
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) =
         error("eval_too_much")
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapImmuneEntity.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapImmuneEntity.kt
@@ -8,13 +8,13 @@ import net.minecraft.world.entity.Entity
 import net.minecraft.world.item.DyeColor
 
 class MishapImmuneEntity(val entity: Entity) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.BLUE)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         env.mishapEnvironment.yeetHeldItemsTowards(entity.position())
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) =
         error("immune_entity", entity.displayName.plainCopy().aqua)
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInternalException.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInternalException.kt
@@ -6,13 +6,13 @@ import at.petrak.hexcasting.api.pigment.FrozenPigment
 import net.minecraft.world.item.DyeColor
 
 class MishapInternalException(val exception: Exception) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.BLACK)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         // NO-OP
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) =
         error("unknown", exception)
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInvalidIota.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInvalidIota.kt
@@ -17,14 +17,14 @@ class MishapInvalidIota(
     val reverseIdx: Int,
     val expected: Component
 ) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.GRAY)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         stack[stack.size - 1 - reverseIdx] = GarbageIota();
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context): Component? {
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context): Component? {
         val perpKey = HexIotaTypes.REGISTRY.getKey(perpetrator.getType())
         
         // this translation key is preferred because it includes the namespace

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInvalidOperatorArgs.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInvalidOperatorArgs.kt
@@ -13,7 +13,7 @@ import net.minecraft.world.item.DyeColor
  * The value failed some kind of predicate.
  */
 class MishapInvalidOperatorArgs(val perpetrators: List<Iota>) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.GRAY)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
@@ -22,7 +22,7 @@ class MishapInvalidOperatorArgs(val perpetrators: List<Iota>) : Mishap() {
         }
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context): Component {
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context): Component {
         return if (perpetrators.size == 1) {
             error(
                 "invalid_operator_args.one",

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInvalidPattern.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInvalidPattern.kt
@@ -14,16 +14,16 @@ class MishapInvalidPattern(val pattern: HexPattern?) : Mishap() {
     @Deprecated("Provide the pattern that caused the mishap as an argument")
     constructor() : this(null) {}
 
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.YELLOW)
 
-    override fun resolutionType(ctx: CastingEnvironment) = ResolvedPatternType.INVALID
+    override fun resolutionType(env: CastingEnvironment) = ResolvedPatternType.INVALID
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         stack.add(GarbageIota())
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context): Component? {
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context): Component? {
         if (pattern == null) return error("invalid_pattern_generic")
         return error("invalid_pattern", PatternIota.display(pattern))
     }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInvalidSpellDatumType.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInvalidSpellDatumType.kt
@@ -9,13 +9,13 @@ import net.minecraft.world.item.DyeColor
  * this is bad
  */
 class MishapInvalidSpellDatumType(val perpetrator: Any) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.BLACK)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         // NO-OP
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) =
         error("invalid_spell_datum_type", this.perpetrator.toString(), this.perpetrator.javaClass.typeName)
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapLackingHotbarItem.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapLackingHotbarItem.kt
@@ -13,14 +13,14 @@ import net.minecraft.world.item.DyeColor
  * @property wanted A text component describing the item or type of item that should have been present.
  */
 class MishapLackingHotbarItem(val wanted: Component) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.BROWN)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         env.mishapEnvironment.dropHeldItems()
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) = error("bad_item.hotbar", wanted)
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) = error("bad_item.hotbar", wanted)
 
     companion object {
         /**

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapLocationInWrongDimension.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapLocationInWrongDimension.kt
@@ -9,16 +9,16 @@ import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.item.DyeColor
 
 class MishapLocationInWrongDimension(val properDimension: ResourceLocation) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.MAGENTA)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         stack.add(GarbageIota())
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context): Component =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context): Component =
         error(
             "wrong_dimension", properDimension.toString(),
-            ctx.world.dimension().location().toString()
+            env.world.dimension().location().toString()
         )
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapNeedsParens.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapNeedsParens.kt
@@ -7,7 +7,7 @@ import at.petrak.hexcasting.api.pigment.FrozenPigment
 import net.minecraft.world.item.DyeColor
 
 class MishapNeedsParens : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.ORANGE)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
@@ -16,6 +16,6 @@ class MishapNeedsParens : Mishap() {
             stack.add(PatternIota(errorCtx.pattern))
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) =
         error("needs_parens")
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapNoAkashicRecord.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapNoAkashicRecord.kt
@@ -7,13 +7,13 @@ import net.minecraft.core.BlockPos
 import net.minecraft.world.item.DyeColor
 
 class MishapNoAkashicRecord(val pos: BlockPos) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.PURPLE)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         env.mishapEnvironment.removeXp(100)
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) =
         error("no_akashic_record", pos.toShortString())
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapNotEnoughArgs.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapNotEnoughArgs.kt
@@ -7,14 +7,14 @@ import at.petrak.hexcasting.api.pigment.FrozenPigment
 import net.minecraft.world.item.DyeColor
 
 class MishapNotEnoughArgs(val expected: Int, val got: Int) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.LIGHT_GRAY)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         repeat(expected - got) { stack.add(GarbageIota()) }
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) =
         if (got == 0)
             error("no_args", expected)
         else

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapNotEnoughMedia.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapNotEnoughMedia.kt
@@ -8,14 +8,14 @@ import at.petrak.hexcasting.api.utils.asTranslatedComponent
 import net.minecraft.world.item.DyeColor
 
 class MishapNotEnoughMedia(private val cost: Long) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.RED)
 
-    override fun resolutionType(ctx: CastingEnvironment) = ResolvedPatternType.ERRORED
+    override fun resolutionType(env: CastingEnvironment) = ResolvedPatternType.ERRORED
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         env.extractMedia(cost, false)
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) = "hexcasting.message.cant_overcast".asTranslatedComponent
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) = "hexcasting.message.cant_overcast".asTranslatedComponent
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapOthersName.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapOthersName.kt
@@ -12,16 +12,16 @@ import net.minecraft.world.item.DyeColor
  * Also throwable for your *own* name, for cases like Chronicler's Gambit
  */
 class MishapOthersName(val confidant: Player) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.BLACK)
 
-    override fun execute(ctx: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
-        val seconds = if (this.confidant == ctx.castingEntity) 5 else 60
-        ctx.mishapEnvironment.blind(seconds * 20)
+    override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
+        val seconds = if (this.confidant == env.castingEntity) 5 else 60
+        env.mishapEnvironment.blind(seconds * 20)
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
-        if (this.confidant == ctx.castingEntity)
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) =
+        if (this.confidant == env.castingEntity)
             error("others_name.self")
         else
             error("others_name", confidant.name)

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapStackSize.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapStackSize.kt
@@ -9,16 +9,16 @@ import at.petrak.hexcasting.common.lib.HexDamageTypes
 import net.minecraft.world.item.DyeColor
 
 class MishapStackSize() : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.BLACK)
 
-    override fun resolutionType(ctx: CastingEnvironment) = ResolvedPatternType.ERRORED
+    override fun resolutionType(env: CastingEnvironment) = ResolvedPatternType.ERRORED
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         stack.clear()
         stack.add(GarbageIota())
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) =
         error("stack_size")
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapUnenlightened.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapUnenlightened.kt
@@ -12,10 +12,10 @@ import net.minecraft.sounds.SoundSource
 import net.minecraft.world.item.DyeColor
 
 class MishapUnenlightened : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.RED)
 
-    override fun resolutionType(ctx: CastingEnvironment) = ResolvedPatternType.INVALID
+    override fun resolutionType(env: CastingEnvironment) = ResolvedPatternType.INVALID
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         env.mishapEnvironment.dropHeldItems()
@@ -31,5 +31,5 @@ class MishapUnenlightened : Mishap() {
         }
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) = null
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) = null
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapUnescapedValue.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapUnescapedValue.kt
@@ -11,7 +11,7 @@ import net.minecraft.world.item.DyeColor
 class MishapUnescapedValue(
     val perpetrator: Iota
 ) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.GRAY)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
@@ -30,6 +30,6 @@ class MishapUnescapedValue(
          */
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) =
         error("unescaped", perpetrator.display())
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/circle/MishapBoolDirectrixEmptyStack.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/circle/MishapBoolDirectrixEmptyStack.kt
@@ -12,13 +12,13 @@ import net.minecraft.world.item.DyeColor
 class MishapBoolDirectrixEmptyStack(
     val pos: BlockPos,
 ) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.GRAY)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         env.world.destroyBlock(this.pos, true)
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context): Component =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context): Component =
         error("circle.bool_directrix.empty_stack", pos.toShortString())
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/circle/MishapBoolDirectrixNotBool.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/circle/MishapBoolDirectrixNotBool.kt
@@ -13,13 +13,13 @@ class MishapBoolDirectrixNotBool(
     val perpetrator: Iota,
     val pos: BlockPos,
 ) : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.GRAY)
 
     override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
         env.world.destroyBlock(this.pos, true)
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context): Component =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context): Component =
         error("circle.bool_directrix.no_bool", pos.toShortString(), perpetrator.display())
 }

--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/circle/MishapNoSpellCircle.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/circle/MishapNoSpellCircle.kt
@@ -11,7 +11,7 @@ import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.enchantment.EnchantmentHelper
 
 class MishapNoSpellCircle : Mishap() {
-    override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment =
         dyeColor(DyeColor.LIGHT_BLUE)
 
     // FIXME: make me work with any entity and not just players
@@ -37,6 +37,6 @@ class MishapNoSpellCircle : Mishap() {
         }
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context) =
         error("no_spell_circle")
 }

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/akashic/OpAkashicWrite.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/akashic/OpAkashicWrite.kt
@@ -60,12 +60,12 @@ object OpAkashicWrite : SpellAction {
                 1f, 0.8f
             )
 
-            // val colorizer = HexPlayerDataHelper.getColorizer(ctx.caster)
+            // val colorizer = HexPlayerDataHelper.getColorizer(env.caster)
             // val normal = record.blockState.getValue(BlockAkashicBookshelf.FACING).normal
             // ParticleSpray(
             //     Vec3.atCenterOf(record.blockPos), Vec3.atBottomCenterOf(normal),
             //     0.5, Math.PI / 4, 10
-            // ).sprayParticles(ctx.world, colorizer)
+            // ).sprayParticles(env.world, colorizer)
         }
     }
 }

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/circles/OpImpetusDir.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/circles/OpImpetusDir.kt
@@ -14,10 +14,10 @@ import at.petrak.hexcasting.api.casting.mishaps.circle.MishapNoSpellCircle
 object OpImpetusDir : ConstMediaAction {
     override val argc = 0
 
-    override fun execute(args: List<Iota>, ctx: CastingEnvironment): List<Iota> {
-        if (ctx !is CircleCastEnv)
+    override fun execute(args: List<Iota>, env: CastingEnvironment): List<Iota> {
+        if (env !is CircleCastEnv)
             throw MishapNoSpellCircle()
 
-        return ctx.circleState().impetusDir.step().asActionResult
+        return env.circleState().impetusDir.step().asActionResult
     }
 }

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/circles/OpImpetusPos.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/circles/OpImpetusPos.kt
@@ -10,10 +10,10 @@ import at.petrak.hexcasting.api.casting.mishaps.circle.MishapNoSpellCircle
 object OpImpetusPos : ConstMediaAction {
     override val argc = 0
 
-    override fun execute(args: List<Iota>, ctx: CastingEnvironment): List<Iota> {
-        if (ctx !is CircleCastEnv)
+    override fun execute(args: List<Iota>, env: CastingEnvironment): List<Iota> {
+        if (env !is CircleCastEnv)
             throw MishapNoSpellCircle()
 
-        return ctx.circleState().impetusPos.asActionResult
+        return env.circleState().impetusPos.asActionResult
     }
 }

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/selectors/OpGetCaster.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/selectors/OpGetCaster.kt
@@ -8,11 +8,11 @@ import at.petrak.hexcasting.api.casting.iota.Iota
 object OpGetCaster : ConstMediaAction {
     override val argc = 0
 
-    override fun execute(args: List<Iota>, ctx: CastingEnvironment): List<Iota> {
-        if (ctx.castingEntity == null)
+    override fun execute(args: List<Iota>, env: CastingEnvironment): List<Iota> {
+        if (env.castingEntity == null)
             return null.asActionResult
 
-        ctx.assertEntityInRange(ctx.castingEntity)
-        return ctx.castingEntity.asActionResult
+        env.assertEntityInRange(env.castingEntity)
+        return env.castingEntity.asActionResult
     }
 }

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/selectors/OpGetEntitiesBy.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/selectors/OpGetEntitiesBy.kt
@@ -38,8 +38,8 @@ class OpGetEntitiesBy(val checker: Predicate<Entity>, val negate: Boolean) : Con
 
     companion object {
         // Ignore truename ambit to fix #792 so you can't slurp up all players in the whole world
-        fun isReasonablySelectable(ctx: CastingEnvironment, e: Entity) =
-            ctx.isEntityInRange(e, true) && e.isAlive && !e.isSpectator
+        fun isReasonablySelectable(env: CastingEnvironment, e: Entity) =
+            env.isEntityInRange(e, true) && e.isAlive && !e.isSpectator
 
         @JvmStatic
         fun isAnimal(e: Entity): Boolean = e is Animal || e is WaterAnimal

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/spells/OpBeep.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/spells/OpBeep.kt
@@ -30,7 +30,7 @@ object OpBeep : SpellAction {
         )
     }
 
-    override fun hasCastingSound(ctx: CastingEnvironment) = false
+    override fun hasCastingSound(env: CastingEnvironment) = false
 
     private data class Spell(val target: Vec3, val note: Int, val instrument: NoteBlockInstrument) : RenderedSpell {
         override fun cast(env: CastingEnvironment) {

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/spells/OpIgnite.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/spells/OpIgnite.kt
@@ -61,11 +61,11 @@ object OpIgnite : SpellAction {
             }
         }
 
-        fun tryToClick(ctx: CastingEnvironment, pos: BlockPos, item: Item): Boolean {
-            return IXplatAbstractions.INSTANCE.isPlacingAllowed(ctx.world, pos, ItemStack(item), ctx.castingEntity as? ServerPlayer) &&
+        fun tryToClick(env: CastingEnvironment, pos: BlockPos, item: Item): Boolean {
+            return IXplatAbstractions.INSTANCE.isPlacingAllowed(env.world, pos, ItemStack(item), env.castingEntity as? ServerPlayer) &&
                 item.useOn(
                     UseOnContext(
-                        ctx.world,
+                        env.world,
                         null,
                         InteractionHand.MAIN_HAND,
                         ItemStack(item),

--- a/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/spells/great/OpBrainsweep.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/common/casting/actions/spells/great/OpBrainsweep.kt
@@ -30,7 +30,7 @@ object OpBrainsweep : SpellAction {
     override val argc = 2
 
     // this way you can hear the villager dying more : )
-    override fun hasCastingSound(ctx: CastingEnvironment) = false
+    override fun hasCastingSound(env: CastingEnvironment) = false
 
     override fun execute(
             args: List<Iota>,

--- a/Common/src/main/java/at/petrak/hexcasting/common/items/magic/ItemPackagedHex.java
+++ b/Common/src/main/java/at/petrak/hexcasting/common/items/magic/ItemPackagedHex.java
@@ -127,8 +127,8 @@ public abstract class ItemPackagedHex extends ItemMediaHolder implements HexHold
             return InteractionResultHolder.fail(stack);
         }
         var sPlayer = (ServerPlayer) player;
-        var ctx = new PackagedItemCastEnv(sPlayer, usedHand);
-        var vm = CastingVM.empty(ctx);
+        var env = new PackagedItemCastEnv(sPlayer, usedHand);
+        var vm = CastingVM.empty(env);
         var clientView = vm.queueExecuteAndWrapIotas(instrs, sPlayer.serverLevel());
 
         boolean broken = breakAfterDepletion() && getMedia(stack) == 0;
@@ -147,10 +147,10 @@ public abstract class ItemPackagedHex extends ItemMediaHolder implements HexHold
             // Somehow we lost spraying particles on each new pattern, so do it here
             // this also nicely prevents particle spam on trinkets
             new ParticleSpray(player.position(), new Vec3(0.0, 1.5, 0.0), 0.4, Math.PI / 3, 30)
-                    .sprayParticles(sPlayer.serverLevel(), ctx.getPigment());
+                    .sprayParticles(sPlayer.serverLevel(), env.getPigment());
         }
 
-        var sound = ctx.getSound().sound();
+        var sound = env.getSound().sound();
         if (sound != null) {
             var soundPos = sPlayer.position();
             sPlayer.level().playSound(null, soundPos.x, soundPos.y, soundPos.z,

--- a/Forge/src/main/java/at/petrak/hexcasting/forge/xplat/ForgeXplatImpl.java
+++ b/Forge/src/main/java/at/petrak/hexcasting/forge/xplat/ForgeXplatImpl.java
@@ -286,9 +286,9 @@ public class ForgeXplatImpl implements IXplatAbstractions {
     @Override
     public CastingVM getStaffcastVM(ServerPlayer player, InteractionHand hand) {
         // This is always from a staff because we don't need to load the VM when casting from item
-        var ctx = new StaffCastEnv(player, hand);
+        var env = new StaffCastEnv(player, hand);
         return new CastingVM(CastingImage.loadFromNbt(player.getPersistentData().getCompound(TAG_VM),
-            player.serverLevel()), ctx);
+            player.serverLevel()), env);
     }
 
     @Override


### PR DESCRIPTION
Resolves #1044 by making the `CastingImage` constructor public. Also changes a bunch of `ctx: CastingEnvironment` parameters to be called `env` instead, both to fix some other warnings (about subclasses using different parameter names than their parents in overridden methods) and because it hasn't been called a CastingContext in years.