### PR TITLE
fix: fabric spellbook scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Fixed Entity Iota comparison to use `equals` on entity IDs instead of reference equality ([#1101](https://github.com/FallingColors/HexMod/pull/1101)) @IridescentVoid
 - Corrected field names of the codec for Pattern Iotas and add a graceful fallback for upgrading ([#1120](https://github.com/FallingColors/HexMod/pull/1120), [#1131](https://github.com/FallingColors/HexMod/pull/1131), [#1140](https://github.com/FallingColors/HexMod/pull/1140)) @Master-Bw3 @IridescentVoid
-- Fixed spellbook scrolling being broken on Fabric ([#1237](https://github.com/FallingColors/HexMod/pull/1237)) @Olfi01
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Fixed Entity Iota comparison to use `equals` on entity IDs instead of reference equality ([#1101](https://github.com/FallingColors/HexMod/pull/1101)) @IridescentVoid
 - Corrected field names of the codec for Pattern Iotas and add a graceful fallback for upgrading ([#1120](https://github.com/FallingColors/HexMod/pull/1120), [#1131](https://github.com/FallingColors/HexMod/pull/1131), [#1140](https://github.com/FallingColors/HexMod/pull/1140)) @Master-Bw3 @IridescentVoid
+- Fixed spellbook scrolling being broken on Fabric ([#1237](https://github.com/FallingColors/HexMod/pull/1237)) @Olfi01
 
 ### Internal
 

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/mixin/client/FabricMouseHandlerMixin.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/mixin/client/FabricMouseHandlerMixin.java
@@ -1,17 +1,17 @@
 package at.petrak.hexcasting.fabric.mixin.client;
 
 import at.petrak.hexcasting.fabric.event.MouseScrollCallback;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.MouseHandler;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(MouseHandler.class)
 public class FabricMouseHandlerMixin {
-    @Inject(method = "onScroll", cancellable = true, locals = LocalCapture.CAPTURE_FAILSOFT, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;isSpectator()Z"))
-    private void onScroll(long winptr, double xOff, double yOff, CallbackInfo ci, double delta) {
+    @Inject(method = "onScroll", cancellable = true, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;isSpectator()Z"))
+    private void onScroll(long l, double d, double e, CallbackInfo ci, @Local(name = "n") int delta) {
         var cancel = MouseScrollCallback.EVENT.invoker().interact(delta);
         if (cancel) {
             ci.cancel();

--- a/Fabric/src/main/java/at/petrak/hexcasting/fabric/mixin/client/FabricMouseHandlerMixin.java
+++ b/Fabric/src/main/java/at/petrak/hexcasting/fabric/mixin/client/FabricMouseHandlerMixin.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(MouseHandler.class)
 public class FabricMouseHandlerMixin {
     @Inject(method = "onScroll", cancellable = true, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;isSpectator()Z"))
-    private void onScroll(long l, double d, double e, CallbackInfo ci, @Local(name = "n") int delta) {
+    private void onScroll(long winptr, double xOff, double yOff, CallbackInfo ci, @Local(name = "n") int delta) {
         var cancel = MouseScrollCallback.EVENT.invoker().interact(delta);
         if (cancel) {
             ci.cancel();


### PR DESCRIPTION
Closes #1198 

The spellbook scrolling outside of the casting GUI was broken in Fabric due to a change in the Minecraft code, which resulted in the Mixin not being applied any more because it was unable to find a variable it required.
This PR fixes the Mixin and uses the more stable `@Local` capture from mixinextras instead of the base Spongepowered capture.