### PR TITLE
make the ingredients shown in the craft-phial recipe viewer tag-based

### DIFF
--- a/Common/src/generated/resources/data/hexcasting/tags/item/phial_raw_ingredients.json
+++ b/Common/src/generated/resources/data/hexcasting/tags/item/phial_raw_ingredients.json
@@ -1,0 +1,9 @@
+{
+  "values": [
+    "hexcasting:amethyst_dust",
+    "minecraft:amethyst_shard",
+    "hexcasting:charged_amethyst",
+    "hexcasting:quenched_allay_shard",
+    "hexcasting:quenched_allay"
+  ]
+}

--- a/Common/src/main/java/at/petrak/hexcasting/api/mod/HexTags.java
+++ b/Common/src/main/java/at/petrak/hexcasting/api/mod/HexTags.java
@@ -19,6 +19,7 @@ public class HexTags {
         public static final TagKey<Item> PHIAL_BASE = create("phial_base");
         public static final TagKey<Item> GRANTS_ROOT_ADVANCEMENT = create("grants_root_advancement");
         public static final TagKey<Item> SEAL_MATERIALS = create("seal_materials");
+        public static final TagKey<Item> PHIAL_RAW_INGREDIENTS = create("phial_raw_ingredients");
 
         public static final TagKey<Item> IMPETI = create("impeti");
         public static final TagKey<Item> DIRECTRICES = create("directrices");
@@ -27,6 +28,7 @@ public class HexTags {
         public static final TagKey<Item> SLATE_BLOCKS = create("slate_blocks");
         public static final TagKey<Item> AMETHYST_BLOCKS = create("amethyst_blocks");
         public static final TagKey<Item> QUENCHED_ALLAY_BLOCKS = create("quenched_allay_blocks");
+
 
         public static TagKey<Item> create(String name) {
             return create(modLoc(name));

--- a/Common/src/main/java/at/petrak/hexcasting/datagen/tag/HexItemTagProvider.java
+++ b/Common/src/main/java/at/petrak/hexcasting/datagen/tag/HexItemTagProvider.java
@@ -1,6 +1,7 @@
 package at.petrak.hexcasting.datagen.tag;
 
 import at.petrak.hexcasting.api.mod.HexTags;
+import at.petrak.hexcasting.common.lib.HexBlocks;
 import at.petrak.hexcasting.common.lib.HexItems;
 import at.petrak.hexcasting.xplat.IXplatTags;
 import net.minecraft.core.HolderLookup;
@@ -45,6 +46,11 @@ public class HexItemTagProvider extends ItemTagsProvider {
             HexItems.CHARGED_AMETHYST.get(), HexItems.CREATIVE_UNLOCKER.get());
         add(tag(HexTags.Items.SEAL_MATERIALS),
             Items.HONEYCOMB);
+
+        add(tag(HexTags.Items.PHIAL_RAW_INGREDIENTS),
+                HexItems.AMETHYST_DUST.get(), Items.AMETHYST_SHARD,
+                HexItems.CHARGED_AMETHYST.get(), HexItems.QUENCHED_SHARD.get(),
+                HexBlocks.QUENCHED_ALLAY.get().asItem());
 
         this.copy(HexTags.Blocks.EDIFIED_LOGS, HexTags.Items.EDIFIED_LOGS);
         this.copy(HexTags.Blocks.EDIFIED_PLANKS, HexTags.Items.EDIFIED_PLANKS);

--- a/Common/src/main/java/at/petrak/hexcasting/interop/utils/PhialRecipeStackBuilder.java
+++ b/Common/src/main/java/at/petrak/hexcasting/interop/utils/PhialRecipeStackBuilder.java
@@ -2,62 +2,61 @@ package at.petrak.hexcasting.interop.utils;
 
 import at.petrak.hexcasting.api.misc.MediaConstants;
 import at.petrak.hexcasting.api.mod.HexConfig;
+import at.petrak.hexcasting.api.mod.HexTags;
+import at.petrak.hexcasting.api.utils.MediaHelper;
 import at.petrak.hexcasting.common.items.magic.ItemMediaBattery;
 import at.petrak.hexcasting.common.lib.HexBlocks;
 import at.petrak.hexcasting.common.lib.HexItems;
 import com.google.common.collect.Lists;
 import com.mojang.datafixers.util.Pair;
+import java.util.Optional;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 
 import java.util.List;
+import net.minecraft.world.level.ItemLike;
 
 public class PhialRecipeStackBuilder {
-    private static ItemStack makeBattery(long unit, int size) {
-        return ItemMediaBattery.withMedia(new ItemStack(HexItems.BATTERY.get()), unit * size, unit * size);
+    private static ItemStack makeBattery(long media) {
+        return ItemMediaBattery.withMedia(new ItemStack(HexItems.BATTERY.get()), media, media);
+    }
+
+    private static final List<Item> FALLBACK_BATTERY_LIST = List.of(
+            HexItems.AMETHYST_DUST.get(),
+            Items.AMETHYST_SHARD,
+            HexItems.CHARGED_AMETHYST.get(),
+            HexItems.QUENCHED_SHARD.get(),
+            HexBlocks.QUENCHED_ALLAY.get().asItem()
+    );
+
+    private static void addPhialRecipe(Item of, int count, List<ItemStack> from, List<ItemStack> to) {
+        ItemStack stack = new ItemStack(of, count);
+        long resultMedia = MediaHelper.extractMedia(stack, -1L, true, true);
+
+        from.add(stack);
+        to.add(makeBattery(resultMedia));
     }
 
     public static Pair<List<ItemStack>, List<ItemStack>> createStacks() {
         List<ItemStack> inputItems = Lists.newArrayList();
         List<ItemStack> outputItems = Lists.newArrayList();
 
-        long dust = HexConfig.common().dustMediaAmount();
-        long shard = HexConfig.common().shardMediaAmount();
-        long charged = HexConfig.common().chargedCrystalMediaAmount();
-        long quenchedShard = MediaConstants.QUENCHED_SHARD_UNIT;
-        long quenchedBlock = MediaConstants.QUENCHED_BLOCK_UNIT;
+        List<Item> toUse = BuiltInRegistries.ITEM.getTag(HexTags.Items.PHIAL_RAW_INGREDIENTS)
+                .map(h -> h.stream().map(Holder::value).toList())
+                .orElse(FALLBACK_BATTERY_LIST);
 
-
-        if (dust > 0) {
-            inputItems.add(new ItemStack(HexItems.AMETHYST_DUST.get(), 1));
-            outputItems.add(makeBattery(dust, 1));
-            inputItems.add(new ItemStack(HexItems.AMETHYST_DUST.get(), 64));
-            outputItems.add(makeBattery(dust, 64));
+        for(Item i : toUse) {
+            addPhialRecipe(i, 1, inputItems, outputItems);
+            if(i.getDefaultMaxStackSize() > 1) {
+                addPhialRecipe(i, i.getDefaultMaxStackSize(), inputItems, outputItems);
+            }
         }
-
-        if (shard > 0) {
-            inputItems.add(new ItemStack(Items.AMETHYST_SHARD, 1));
-            outputItems.add(makeBattery(shard, 1));
-            inputItems.add(new ItemStack(Items.AMETHYST_SHARD, 64));
-            outputItems.add(makeBattery(shard, 64));
-        }
-
-        if (charged > 0) {
-            inputItems.add(new ItemStack(HexItems.CHARGED_AMETHYST.get(), 1));
-            outputItems.add(makeBattery(charged, 1));
-            inputItems.add(new ItemStack(HexItems.CHARGED_AMETHYST.get(), 64));
-            outputItems.add(makeBattery(charged, 64));
-        }
-
-        inputItems.add(new ItemStack(HexItems.QUENCHED_SHARD.get(), 1));
-        outputItems.add(makeBattery(quenchedShard, 1));
-        inputItems.add(new ItemStack(HexItems.QUENCHED_SHARD.get(), 64));
-        outputItems.add(makeBattery(quenchedShard, 64));
-
-        inputItems.add(new ItemStack(HexBlocks.QUENCHED_ALLAY.get(), 1));
-        outputItems.add(makeBattery(quenchedBlock, 1));
-        inputItems.add(new ItemStack(HexBlocks.QUENCHED_ALLAY.get(), 64));
-        outputItems.add(makeBattery(quenchedBlock, 64));
 
         return new Pair<>(inputItems, outputItems);
     }

--- a/Fabric/src/generated/resources/data/hexcasting/tags/item/phial_raw_ingredients.json
+++ b/Fabric/src/generated/resources/data/hexcasting/tags/item/phial_raw_ingredients.json
@@ -1,0 +1,9 @@
+{
+  "values": [
+    "hexcasting:amethyst_dust",
+    "minecraft:amethyst_shard",
+    "hexcasting:charged_amethyst",
+    "hexcasting:quenched_allay_shard",
+    "hexcasting:quenched_allay"
+  ]
+}

--- a/Neoforge/src/generated/resources/data/hexcasting/tags/item/phial_raw_ingredients.json
+++ b/Neoforge/src/generated/resources/data/hexcasting/tags/item/phial_raw_ingredients.json
@@ -1,0 +1,9 @@
+{
+  "values": [
+    "hexcasting:amethyst_dust",
+    "minecraft:amethyst_shard",
+    "hexcasting:charged_amethyst",
+    "hexcasting:quenched_allay_shard",
+    "hexcasting:quenched_allay"
+  ]
+}


### PR DESCRIPTION
Fixes #1154

Before this change, EMI mismatched the phial with the ingredient it comes from. After this change, that buggy behavior still occurs, and there's new buggy behavior that the 64-stacks aren't shown (despite them being passed directly to EmiPhialRecipe). No idea how that's happening. EMI may be haunted or something.