### PR TITLE
fix: properly track argument presence in the hex notebook

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/interop/patchouli/PatternProcessor.java
+++ b/Common/src/main/java/at/petrak/hexcasting/interop/patchouli/PatternProcessor.java
@@ -21,12 +21,12 @@ public class PatternProcessor implements IComponentProcessor {
             String prefix = "hexcasting.action.";
             boolean hasOverride = I18n.exists(prefix + "book." + opName);
             translationKey = prefix + (hasOverride ? "book." : "") + opName;
-
-            if (vars.has("input") && !vars.get("input").asString().isEmpty())
-                hasArgs = true;
-            else if (vars.has("output") && !vars.get("output").asString().isEmpty())
-                hasArgs = true;
         }
+
+        if (vars.has("input") && !vars.get("input").asString().isEmpty())
+            hasArgs = true;
+        else if (vars.has("output") && !vars.get("output").asString().isEmpty())
+            hasArgs = true;
     }
 
     @Override


### PR DESCRIPTION
Regression from #1118 

Prior to this fix, pages that had their header overwritten would not have their signatures visible on the book page. This affects Additive Distillation in the lists entry, and probably other entries.
