### PR TITLE
[1.21] Fixed & extended MishapInternalException

### DIFF
--- a/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInternalException.kt
+++ b/Common/src/main/java/at/petrak/hexcasting/api/casting/mishaps/MishapInternalException.kt
@@ -4,7 +4,13 @@ import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
 import at.petrak.hexcasting.api.casting.iota.Iota
 import at.petrak.hexcasting.api.pigment.FrozenPigment
 import at.petrak.hexcasting.api.utils.TreeList
+import net.minecraft.network.chat.ClickEvent
+import net.minecraft.network.chat.Component
+import net.minecraft.network.chat.HoverEvent
+import net.minecraft.network.chat.Style
 import net.minecraft.world.item.DyeColor
+import java.io.PrintWriter
+import java.io.StringWriter
 
 class MishapInternalException(val exception: Exception) : Mishap() {
     override fun accentColor(ctx: CastingEnvironment, errorCtx: Context): FrozenPigment =
@@ -15,6 +21,21 @@ class MishapInternalException(val exception: Exception) : Mishap() {
         return stack
     }
 
-    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context) =
-        error("unknown", exception)
+    override fun errorMessage(ctx: CastingEnvironment, errorCtx: Context): Component {
+        var message = Component.literal("$exception")
+
+        // dump stack trace
+        val sw = StringWriter()
+        val pw = PrintWriter(sw)
+        exception.printStackTrace(pw)
+        val trace = sw.toString()
+
+        message = message.withStyle(
+            Style.EMPTY
+                .withClickEvent(ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, trace))
+                .withHoverEvent(HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(trace)))
+        )
+
+        return error("unknown", message)
+    }
 }


### PR DESCRIPTION
fixes #1229
<img width="631" height="61" alt="image" src="https://github.com/user-attachments/assets/5c8edea8-9eab-4db8-92f6-0a269ef57e66" />

and adds detailed stacktrace (hover + click copy) for its debugging purpose
<img width="474" height="182" alt="image" src="https://github.com/user-attachments/assets/67df25c7-a6a0-462f-9c92-900dcfe55fd7" />
